### PR TITLE
Live pixel validation: remove cache-buster before parameter validation

### DIFF
--- a/bin/validate_live_pixel.mjs
+++ b/bin/validate_live_pixel.mjs
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import fs from 'fs';
 import JSON5 from 'json5';
 

--- a/src/params_validator.mjs
+++ b/src/params_validator.mjs
@@ -140,7 +140,8 @@ export class ParamsValidator {
 
         const urlSplit = url.split('/')[2].split('?');
         const livePixelName = urlSplit[0].replaceAll('_', '.');
-        const livePixelRequestParams = urlSplit[1];
+        // grab pixel parameters with any preciding cache buster removed
+        const livePixelRequestParams = /^([0-9]+&)?(.*)$/.exec(urlSplit[1] || '')[2];
 
         // 1) Validate pixel name if it's parameterized
         if (livePixelName.length > prefix.length) {

--- a/tests/live_pixel_validation_test.mjs
+++ b/tests/live_pixel_validation_test.mjs
@@ -46,6 +46,13 @@ describe('No common params nor suffixes', () => {
         const expectedErrors = ["must NOT have additional properties. Found extra property 'param2'"];
         expect(errors).to.have.members(expectedErrors);
     });
+
+    it('ignores cache buster', () => {
+        const prefix = 'simplePixel';
+        const url = `/t/${prefix}?12345&param1=true`;
+        const errors = paramsValidator.validateLivePixels(pixelDefs[prefix], prefix, url);
+        expect(errors).to.be.empty;
+    });
 });
 
 describe('Common params', () => {


### PR DESCRIPTION
- On most platforms, we send a cache buster string with pixel requests, e.g. `/t/pixel?12345&param=1`
- When validating URLs including this string, the current validator assumes that this is a parameter, and thus marks the parameters as invalid.
- We can parse the cache-buster out before parsing the URL query parameters to prevent this.