### PR TITLE
Change limit from 28 to 7 days

### DIFF
--- a/live_validation_scripts/validate_live_pixel.mjs
+++ b/live_validation_scripts/validate_live_pixel.mjs
@@ -48,6 +48,14 @@ function main(mainDir, csvFile) {
                 fileUtils.getUndocumentedPixelsPath(mainDir),
                 JSON.stringify(Array.from(liveValidator.undocumentedPixels), null, 4),
             );
+
+            /*
+                This script will fail if there are too many errors to write out the JSON.
+                For now we are limiting the validation to the last 7 days in 
+                clickhouse_fetcher.mjs and that keeps the JSON at an acceptable size. 
+                Long term we can revisit this for a more robust solution.
+
+            */
             fs.writeFileSync(fileUtils.getPixelErrorsPath(mainDir), JSON.stringify(liveValidator.pixelErrors, setReplacer, 4));
             console.log(`Validation results saved to ${fileUtils.getResultsDir(mainDir)}`);
         });

--- a/live_validation_scripts/validate_live_pixel.mjs
+++ b/live_validation_scripts/validate_live_pixel.mjs
@@ -51,7 +51,7 @@ function main(mainDir, csvFile) {
 
             /*
                 This script will fail if there are too many errors to write out the JSON.
-                For now we are limiting the validation to the last 7 days in 
+                For now we can limit the validation to the last 7 days in 
                 clickhouse_fetcher.mjs and that keeps the JSON at an acceptable size. 
                 Long term we can revisit this for a more robust solution.
 

--- a/live_validation_scripts/validate_live_pixel.mjs
+++ b/live_validation_scripts/validate_live_pixel.mjs
@@ -51,12 +51,24 @@ function main(mainDir, csvFile) {
 
             /*
                 This script will fail if there are too many errors to write out the JSON.
-                For now we can limit the validation to the last 7 days in 
+                For now we could limit the validation to the last 7 days in 
                 clickhouse_fetcher.mjs and that keeps the JSON at an acceptable size. 
-                Long term we can revisit this for a more robust solution.
+                Longer term we can revisit this for a more robust solution.
 
             */
-            fs.writeFileSync(fileUtils.getPixelErrorsPath(mainDir), JSON.stringify(liveValidator.pixelErrors, setReplacer, 4));
+            try {
+                fs.writeFileSync(
+                    fileUtils.getPixelErrorsPath(mainDir),
+                    JSON.stringify(liveValidator.pixelErrors, setReplacer, 4)
+                );
+            } catch (err) {
+                if (err instanceof RangeError) {
+                    console.error('Error: Validation results are too large to write to JSON. Try limiting the validation range (DAYS_TO_FETCH).');
+                    process.exit(1);
+                } else {
+                    throw err;
+                }
+            }
             console.log(`Validation results saved to ${fileUtils.getResultsDir(mainDir)}`);
         });
 }

--- a/src/clickhouse_fetcher.mjs
+++ b/src/clickhouse_fetcher.mjs
@@ -7,7 +7,7 @@ import { readTokenizedPixels, readProductDef } from './file_utils.mjs';
 const MAX_MEMORY = 2 * 1024 * 1024 * 1024; // 2GB
 const TMP_TABLE_NAME = 'temp.pixel_validation';
 const CH_ARGS = [`--max_memory_usage=${MAX_MEMORY}`, '-h', 'clickhouse', '--query'];
-const DAYS_TO_FETCH = 7; // Number of days to fetch pixels for
+const DAYS_TO_FETCH = 28; // Number of days to fetch pixels for; Reduce this (e.g. to 7) if hit limit on JSON size in validate_live_pixel.mjs
 
 function createTempTable() {
     const queryString = `CREATE TABLE ${TMP_TABLE_NAME}

--- a/src/clickhouse_fetcher.mjs
+++ b/src/clickhouse_fetcher.mjs
@@ -7,6 +7,7 @@ import { readTokenizedPixels, readProductDef } from './file_utils.mjs';
 const MAX_MEMORY = 2 * 1024 * 1024 * 1024; // 2GB
 const TMP_TABLE_NAME = 'temp.pixel_validation';
 const CH_ARGS = [`--max_memory_usage=${MAX_MEMORY}`, '-h', 'clickhouse', '--query'];
+const DAYS_TO_FETCH = 7; // Number of days to fetch pixels for
 
 function createTempTable() {
     const queryString = `CREATE TABLE ${TMP_TABLE_NAME}
@@ -41,7 +42,7 @@ function populateTempTable(tokenizedPixels, productDef) {
     const agentWhereClause = productDef.agents.map((agent) => `agent = '${agent}'`).join(' OR ');
 
     const currentDate = new Date();
-    const pastDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate() - 28);
+    const pastDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate() - DAYS_TO_FETCH);
     /* eslint-disable no-unmodified-loop-condition */
     while (pastDate <= currentDate) {
         const queryString = `INSERT INTO ${TMP_TABLE_NAME} (pixel, params)


### PR DESCRIPTION
We were running into a limit on the errors we could write to JSON in the `validate_live_pixel.mjs` script. Changing to audit 7 days rather than 28 for now. 
