### PR TITLE
Add nested suffixs to schema, support Android validation

### DIFF
--- a/bin/validate_schema.mjs
+++ b/bin/validate_schema.mjs
@@ -49,8 +49,8 @@ const globalIgnoreParams = fileUtils.readIgnoreParams(fileUtils.GLOBAL_PIXEL_DIR
 const ignoreParams = { ...pixelIgnoreParams, ...globalIgnoreParams };
 
 const validator = new DefinitionsValidator(commonParams, commonSuffixes, ignoreParams);
-logErrors('ERROR in common_params.json:', validator.validateCommonParamsDefinition());
-logErrors('ERROR in common_suffixes.json:', validator.validateCommonSuffixesDefinition());
+logErrors('ERROR in params_dictionary.json:', validator.validateCommonParamsDefinition());
+logErrors('ERROR in suffixes_dictionary.json:', validator.validateCommonSuffixesDefinition());
 logErrors('ERROR in ignore_params.json:', validator.validateIgnoreParamsDefinition());
 
 // 2) Validate experiments

--- a/schemas/suffix_schema.json5
+++ b/schemas/suffix_schema.json5
@@ -23,6 +23,13 @@
                 {
                     "type": "string",
                     "description": "Shortcut to a common suffix"
+                },
+                {
+                    "type": "array",
+                    "description": "Array of nested suffixes",
+                    "items": {
+                        "$ref": "#/$defs/suffix"
+                    }
                 }
             ]
         }

--- a/scripts/revalidateRepo.sh
+++ b/scripts/revalidateRepo.sh
@@ -19,6 +19,4 @@ fnm exec npm run preprocess-defs $MAIN_DIR
 echo "Validate pixels"
 fnm exec npm run validate-live-pixels $MAIN_DIR $CSV_FILE
 
-rm -rf $CSV_FILE
-
 exit 0


### PR DESCRIPTION
For: https://app.asana.com/1/137249556945/project/72649045549333/task/1210907475542624?focus=true

- Fix local validation for suffix arrays (already supported in live validation)
- Fix some filenames in debug messages
- 