### PR TITLE
Support case sensitive (camelCase) suffix shortcuts

### DIFF
--- a/src/live_pixel_validator.mjs
+++ b/src/live_pixel_validator.mjs
@@ -151,7 +151,7 @@ export class LivePixelsValidator {
 
             const normalizedParams = pixelDef.parameters ? JSON.parse(this.#getNormalizedVal(JSON.stringify(pixelDef.parameters))) : [];
             // Clone suffixes before compilation to avoid mutating tokenized definitions.
-            const normalizedSuffixes = pixelDef.suffixes ? JSON.parse(JSON.stringify(pixelDef.suffixes)) : [];
+            const parsedSuffixes = pixelDef.suffixes ? JSON.parse(JSON.stringify(pixelDef.suffixes)) : [];
 
             // Pre-compile each schema and remember owners
             const paramsSchema = paramsValidator.compileParamsSchema(normalizedParams, currentPrefix);

--- a/src/live_pixel_validator.mjs
+++ b/src/live_pixel_validator.mjs
@@ -155,7 +155,7 @@ export class LivePixelsValidator {
 
             // Pre-compile each schema and remember owners
             const paramsSchema = paramsValidator.compileParamsSchema(normalizedParams, currentPrefix);
-            const suffixesSchema = paramsValidator.compileSuffixesSchema(normalizedSuffixes);
+            const suffixesSchema = paramsValidator.compileSuffixesSchema(parsedSuffixes);
             const owners = pixelDef.owners;
             const requireVersion = pixelDef.requireVersion ?? false;
             tokenizedPixels[prefixPart] = {

--- a/src/live_pixel_validator.mjs
+++ b/src/live_pixel_validator.mjs
@@ -149,13 +149,13 @@ export class LivePixelsValidator {
                 return;
             }
 
-            // Pixel name is always lower case:
-            const lowerCasedSuffixes = pixelDef.suffixes ? JSON.parse(JSON.stringify(pixelDef.suffixes).toLowerCase()) : [];
             const normalizedParams = pixelDef.parameters ? JSON.parse(this.#getNormalizedVal(JSON.stringify(pixelDef.parameters))) : [];
+            // Clone suffixes before compilation to avoid mutating tokenized definitions.
+            const normalizedSuffixes = pixelDef.suffixes ? JSON.parse(JSON.stringify(pixelDef.suffixes)) : [];
 
             // Pre-compile each schema and remember owners
             const paramsSchema = paramsValidator.compileParamsSchema(normalizedParams, currentPrefix);
-            const suffixesSchema = paramsValidator.compileSuffixesSchema(lowerCasedSuffixes);
+            const suffixesSchema = paramsValidator.compileSuffixesSchema(normalizedSuffixes);
             const owners = pixelDef.owners;
             const requireVersion = pixelDef.requireVersion ?? false;
             tokenizedPixels[prefixPart] = {

--- a/src/params_validator.mjs
+++ b/src/params_validator.mjs
@@ -91,6 +91,26 @@ export class ParamsValidator {
     }
 
     /**
+     * Normalizes suffix value fields to lowercase while preserving shortcut keys.
+     * Applies only to resolved schema values (e.g. key/const/enum).
+     * @param {object} suffix
+     * @returns {void}
+     */
+    lowerCaseSuffixValueFields(suffix) {
+        traverse(suffix, (schema) => {
+            if (typeof schema.key === 'string') {
+                schema.key = schema.key.toLowerCase();
+            }
+            if (typeof schema.const === 'string') {
+                schema.const = schema.const.toLowerCase();
+            }
+            if (Array.isArray(schema.enum)) {
+                schema.enum = schema.enum.map((val) => (typeof val === 'string' ? val.toLowerCase() : val));
+            }
+        });
+    }
+
+    /**
      * Replaces shortcuts to common suffixes and compiles the suffix schema.
      * Supports either:
      *  - a single ordered list of suffixes, e.g. ['a','b','c']
@@ -108,6 +128,7 @@ export class ParamsValidator {
             let idx = 0;
             sequence.forEach((item) => {
                 const suffix = this.getUpdatedItem(item, this.#commonSuffixes);
+                this.lowerCaseSuffixValueFields(suffix);
                 if (suffix.key) {
                     // Static token in the pixel name
                     properties[idx] = { enum: [suffix.key] };

--- a/tests/live_pixel_validation_test.mjs
+++ b/tests/live_pixel_validation_test.mjs
@@ -434,6 +434,41 @@ describe('Alternative suffix sequences (anyOf)', () => {
     });
 });
 
+describe('Case-insensitive suffix shortcut resolution', () => {
+    it('keeps camelCase shortcut lookup while lowercasing resolved suffix values', () => {
+        const caseInsensitiveProductDef = {
+            target: {
+                key: 'appVersion',
+                version: '1.0.0',
+            },
+            agents: [],
+            forceLowerCase: true,
+        };
+
+        const commonSuffixes = {
+            webviewInitRunType: {
+                key: 'webviewInitRunType',
+                enum: ['control', 'experiment'],
+            },
+        };
+        const paramsValidator = new ParamsValidator({}, commonSuffixes, {});
+        const pixelDefs = {
+            simplePixel: {
+                suffixes: ['webviewInitRunType'],
+            },
+        };
+
+        const tokenizedDefs = {};
+        tokenizePixelDefs(pixelDefs, tokenizedDefs);
+        const liveValidator = new LivePixelsValidator(tokenizedDefs, caseInsensitiveProductDef, {}, paramsValidator);
+
+        const pixel = 'simplePixel_webviewinitruntype_control';
+        const pixelStatus = liveValidator.validatePixel(pixel, '');
+        expect(pixelStatus.status).to.equal(PIXEL_VALIDATION_RESULT.VALIDATION_PASSED);
+        expect(pixelStatus.errors).to.be.empty;
+    });
+});
+
 describe('Require version', () => {
     const productDefWithVersion = {
         target: {

--- a/tests/test_data/valid/pixels/definitions/pixel_subfolder/test_pixels.json
+++ b/tests/test_data/valid/pixels/definitions/pixel_subfolder/test_pixels.json
@@ -25,5 +25,11 @@
         "owners": ["tester"],
         "triggers": ["other"],
         "suffixes": [["first_daily_count"], ["device_type", "first_daily_count"]]
+    },
+    "test_pattern_suffix": {
+        "description": "Test pixel with a case-sensitive regex pattern suffix shortcut",
+        "owners": ["tester"],
+        "triggers": ["other"],
+        "suffixes": ["nonNumericChar"]
     }
 }

--- a/tests/test_data/valid/pixels/expected_processing_results/pixel_errors.json
+++ b/tests/test_data/valid/pixels/expected_processing_results/pixel_errors.json
@@ -89,5 +89,24 @@
         "must be equal to one of the allowed values": [
             "metric=search&value=invalid"
         ]
+    },
+    "test_nested_suffixes": {
+        "owners": [
+            "tester"
+        ],
+        "Suffix 'invalid' must be equal to one of the allowed values": [
+            "test_nested_suffixes_invalid"
+        ],
+        "must match a schema in anyOf": [
+            "test_nested_suffixes_invalid"
+        ]
+    },
+    "test_pattern_suffix": {
+        "owners": [
+            "tester"
+        ],
+        "/0 must match pattern \"^\\D$\"": [
+            "test_pattern_suffix_1"
+        ]
     }
 }

--- a/tests/test_data/valid/pixels/expected_processing_results/tokenized_pixels.json
+++ b/tests/test_data/valid/pixels/expected_processing_results/tokenized_pixels.json
@@ -153,6 +153,18 @@
                     ]
                 }
             }
+        },
+        "pattern": {
+            "suffix": {
+                "__root_prefix__": {
+                    "owners": [
+                        "tester"
+                    ],
+                    "suffixes": [
+                        "nonNumericChar"
+                    ]
+                }
+            }
         }
     }
 }

--- a/tests/test_data/valid/pixels/suffixes_dictionary.json
+++ b/tests/test_data/valid/pixels/suffixes_dictionary.json
@@ -9,5 +9,10 @@
         "type": "string",
         "description": "The type of device used by the user.",
         "enum": ["phone", "tablet"]
+    },
+    "nonNumericChar": {
+        "type": "string",
+        "description": "Non-numeric single character suffix",
+        "pattern": "^\\D$"
     }
 }

--- a/tests/test_data/valid/pixels/test_live_pixels.csv
+++ b/tests/test_data/valid/pixels/test_live_pixels.csv
@@ -28,3 +28,8 @@ experiment.metrics.defaultBrowser.control.android.tablet,"['metric=stageImpressi
 experiment.metrics.defaultBrowser.control.android.tablet,"['metric=app_use', 'value=4']",
 experiment.metrics.defaultBrowser.control.android.tablet,"['metric=search', 'value=21']",
 experiment.metrics.defaultBrowser.control.android.tablet,"['metric=search', 'value=invalid']",
+test.nested.suffixes.first,[],
+test.nested.suffixes.android.phone.daily,[],
+test.nested.suffixes.invalid,[],
+test.pattern.suffix.a,[],
+test.pattern.suffix.1,[],

--- a/tests/validate_schema_cli_test.mjs
+++ b/tests/validate_schema_cli_test.mjs
@@ -145,7 +145,9 @@ describe('validate_schema.mjs CLI branches', () => {
             const result = runValidateSchema([defsCopy]);
 
             expect(result.status).to.equal(1);
-            expect(result.stderr).to.include('ERROR in product.json target version: Cannot specify both "version" and "versionUrl"/"versionRef"');
+            expect(result.stderr).to.include(
+                'ERROR in product.json target version: Cannot specify both "version" and "versionUrl"/"versionRef"',
+            );
         } finally {
             fs.rmSync(defsCopy, { recursive: true, force: true });
         }

--- a/tests/validate_schema_cli_test.mjs
+++ b/tests/validate_schema_cli_test.mjs
@@ -1,0 +1,153 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+const validDefsPath = path.join('tests', 'test_data', 'valid');
+
+function createTempDefsCopy() {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pixel-schema-validate-schema-'));
+    fs.cpSync(validDefsPath, tempDir, { recursive: true });
+    return tempDir;
+}
+
+function runValidateSchema(args) {
+    return spawnSync('node', ['./bin/validate_schema.mjs', ...args], {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+    });
+}
+
+describe('validate_schema.mjs CLI branches', () => {
+    it('validates a single pixel definition file when --file targets pixels', () => {
+        const defsCopy = createTempDefsCopy();
+        try {
+            const result = runValidateSchema([defsCopy, '--file', 'pixel_subfolder/test_pixels.json']);
+
+            expect(result.status).to.equal(0);
+            expect(result.stderr.trim()).to.equal('');
+            expect(result.stdout).to.include('Validating pixels definition:');
+        } finally {
+            fs.rmSync(defsCopy, { recursive: true, force: true });
+        }
+    });
+
+    it('validates a single wide event file when --file targets wide_events', () => {
+        const defsCopy = createTempDefsCopy();
+        try {
+            const result = runValidateSchema([defsCopy, '--file', 'wide_events.json']);
+
+            expect(result.status).to.equal(0);
+            expect(result.stderr.trim()).to.equal('');
+            expect(result.stdout).to.include('Validating wide events definition:');
+        } finally {
+            fs.rmSync(defsCopy, { recursive: true, force: true });
+        }
+    });
+
+    it('exits with an error when --file does not exist in pixels or wide_events', () => {
+        const defsCopy = createTempDefsCopy();
+        try {
+            const result = runValidateSchema([defsCopy, '--file', 'does-not-exist.json']);
+
+            expect(result.status).to.equal(1);
+            expect(result.stderr).to.include('File not found in pixels or wide_events definitions: does-not-exist.json');
+        } finally {
+            fs.rmSync(defsCopy, { recursive: true, force: true });
+        }
+    });
+
+    it('exits with an error when github user map path is invalid', () => {
+        const defsCopy = createTempDefsCopy();
+        const invalidUserMapPath = path.join(defsCopy, 'pixels', 'missing-user-map.yml');
+        try {
+            const result = runValidateSchema([defsCopy, '--githubUserMap', invalidUserMapPath]);
+
+            expect(result.status).to.equal(1);
+            expect(result.stderr).to.include(`Error reading GitHub user map from ${invalidUserMapPath}:`);
+        } finally {
+            fs.rmSync(defsCopy, { recursive: true, force: true });
+        }
+    });
+
+    it('reports validation errors for malformed search_experiments.json input', () => {
+        const defsCopy = createTempDefsCopy();
+        const searchExperimentsPath = path.join(defsCopy, 'pixels', 'search_experiments.json');
+        fs.writeFileSync(searchExperimentsPath, '{', 'utf8');
+
+        try {
+            const result = runValidateSchema([defsCopy]);
+
+            expect(result.status).to.equal(1);
+            expect(result.stderr).to.include('ERROR in search_experiments.json: must be object');
+        } finally {
+            fs.rmSync(defsCopy, { recursive: true, force: true });
+        }
+    });
+
+    it('skips directories while recursively validating wide event definitions', () => {
+        const defsCopy = createTempDefsCopy();
+        const nestedWideEventDir = path.join(defsCopy, 'wide_events', 'definitions', 'nested');
+        const emptyWideEventDir = path.join(defsCopy, 'wide_events', 'definitions', 'empty');
+        fs.mkdirSync(nestedWideEventDir, { recursive: true });
+        fs.mkdirSync(emptyWideEventDir, { recursive: true });
+        fs.writeFileSync(path.join(nestedWideEventDir, 'nested_wide_events.json'), '{}', 'utf8');
+
+        try {
+            const result = runValidateSchema([defsCopy]);
+
+            expect(result.status).to.equal(0);
+            expect(result.stdout).to.include('nested_wide_events.json');
+        } finally {
+            fs.rmSync(defsCopy, { recursive: true, force: true });
+        }
+    });
+
+    it('exits with an error when wide_events exists but base_event.json is missing', () => {
+        const defsCopy = createTempDefsCopy();
+        fs.rmSync(path.join(defsCopy, 'wide_events', 'base_event.json'));
+
+        try {
+            const result = runValidateSchema([defsCopy]);
+
+            expect(result.status).to.equal(1);
+            expect(result.stderr).to.include('ERROR: base_event.json is required for wide event validation');
+        } finally {
+            fs.rmSync(defsCopy, { recursive: true, force: true });
+        }
+    });
+
+    it('returns top-level error when file parsing throws unexpectedly', () => {
+        const defsCopy = createTempDefsCopy();
+        const brokenPixelPath = path.join(defsCopy, 'pixels', 'definitions', 'pixel_subfolder', 'broken_pixel.json');
+        fs.writeFileSync(brokenPixelPath, '{', 'utf8');
+
+        try {
+            const result = runValidateSchema([defsCopy, '--file', 'pixel_subfolder/broken_pixel.json']);
+
+            expect(result.status).to.equal(1);
+            expect(result.stderr).to.include('Error:');
+        } finally {
+            fs.rmSync(defsCopy, { recursive: true, force: true });
+        }
+    });
+
+    it('exits with an error when product target version configuration is invalid', () => {
+        const defsCopy = createTempDefsCopy();
+        const productPath = path.join(defsCopy, 'product.json');
+        const productDef = JSON.parse(fs.readFileSync(productPath, 'utf8'));
+        productDef.target.versionUrl = 'https://example.com/version.json';
+        productDef.target.versionRef = 'version';
+        fs.writeFileSync(productPath, `${JSON.stringify(productDef, null, 4)}\n`, 'utf8');
+
+        try {
+            const result = runValidateSchema([defsCopy]);
+
+            expect(result.status).to.equal(1);
+            expect(result.stderr).to.include('ERROR in product.json target version: Cannot specify both "version" and "versionUrl"/"versionRef"');
+        } finally {
+            fs.rmSync(defsCopy, { recursive: true, force: true });
+        }
+    });
+});

--- a/tests/validate_schema_cli_test.mjs
+++ b/tests/validate_schema_cli_test.mjs
@@ -86,7 +86,7 @@ describe('validate_schema.mjs CLI branches', () => {
         }
     });
 
-    it('skips directories while recursively validating wide event definitions', () => {
+    it('skips empty directories while recursively validating wide event definitions', () => {
         const defsCopy = createTempDefsCopy();
         const nestedWideEventDir = path.join(defsCopy, 'wide_events', 'definitions', 'nested');
         const emptyWideEventDir = path.join(defsCopy, 'wide_events', 'definitions', 'empty');


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1209805270658160/task/1213530921998047?focus=true

Suffix dictionary should support case sensitive shortcuts like param dictionary already does.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes suffix shortcut handling during schema compilation, which can alter live pixel validation outcomes (especially in `forceLowerCase` mode). Risk is moderate because it touches core validation logic but is covered by added tests and test fixtures.
> 
> **Overview**
> Updates suffix schema compilation to **preserve case-sensitive (camelCase) shortcut keys** while still lowercasing the *resolved* suffix schema values (`key`/`const`/`enum`) for case-insensitive products.
> 
> Removes the previous global lowercasing of `pixelDef.suffixes` in `LivePixelsValidator` and instead lowercases suffix value fields after shortcut expansion in `ParamsValidator`; adds coverage for this behavior plus new fixture data for nested suffix validation and a regex-pattern suffix shortcut, and introduces a new `validate_schema.mjs` CLI test suite for several success/error branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a8db66fe438e48f52c80dfc0070570fe957824a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->