### PR TITLE
Skip pixels lacking version when defined, remove requireVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Each pixel **must** contain the following properties:
   * `other`: catch-all
 
 Additionally, a pixel **may** contain the following properties:
-* `requireVersion` - when set to `true`, **live validation** will treat any pixel instances without a version param as being out of date.  Defaults to `false`.
 
 #### Pixels with dynamic names
 If the pixel name is parameterized, you can utilize the `suffixes` property.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ Each pixel **must** contain the following properties:
   * `exception`: pixel fires when an exception/crash occurs
   * `other`: catch-all
 
-Additionally, a pixel **may** contain the following properties:
 
 #### Pixels with dynamic names
 If the pixel name is parameterized, you can utilize the `suffixes` property.

--- a/schemas/pixel_schema.json5
+++ b/schemas/pixel_schema.json5
@@ -58,10 +58,6 @@
                         ]
                     }
                 },
-                "requireVersion": {
-                    "type": "boolean",
-                    "description": "Whether pixels lacking version info shoudld be skipped.  Default is false (all pixels included)."
-                },
                 "suffixes": {
                     "type": "array",
                     "description": "List of pixel suffix combinations under the main pixel prefix. Can be a shortcut to a common suffix",

--- a/src/live_pixel_validator.mjs
+++ b/src/live_pixel_validator.mjs
@@ -157,12 +157,10 @@ export class LivePixelsValidator {
             const paramsSchema = paramsValidator.compileParamsSchema(normalizedParams, currentPrefix);
             const suffixesSchema = paramsValidator.compileSuffixesSchema(parsedSuffixes);
             const owners = pixelDef.owners;
-            const requireVersion = pixelDef.requireVersion ?? false;
             tokenizedPixels[prefixPart] = {
                 paramsSchema,
                 suffixesSchema,
                 owners,
-                requireVersion,
             };
         });
     }
@@ -278,7 +276,6 @@ export class LivePixelsValidator {
         // Found a match: remember owners
         // TODO: experiments don't have owners. Fix in https://app.asana.com/1/137249556945/project/1209805270658160/task/1210955210382823?focus=true
         this.#currentPixelState.owners = pixelMatch.owners;
-        this.#currentPixelState.requireVersion = pixelMatch.requireVersion;
 
         this.validatePixelParamsAndSuffixes(prefix, pixel, params, pixelMatch);
         return this.#currentPixelState;
@@ -302,8 +299,9 @@ export class LivePixelsValidator {
         });
 
         if (this.#defsVersionKey && this.#defsVersion) {
-            // 1) Skip pixels where requireVersion is set but version param is absent
-            if (this.#currentPixelState.requireVersion && !paramsStruct[this.#defsVersionKey]) {
+            const hasTargetVersionParam = !!this.#getParamSchemaForKey(this.#defsVersionKey, pixelSchemas.paramsSchema.schema);
+            // 1) Skip pixels that define the app version key but do not include it in the live params.
+            if (hasTargetVersionParam && !paramsStruct[this.#defsVersionKey]) {
                 this.#currentPixelState.status = PIXEL_VALIDATION_RESULT.OLD_APP_VERSION;
                 return this.#currentPixelState;
             }

--- a/src/tokenizer.mjs
+++ b/src/tokenizer.mjs
@@ -28,10 +28,9 @@ export function tokenizePixelDefs(pixelDefs, existingTokenizedDefs) {
             throw new Error(`Duplicate pixel definition found for ${prefix}`);
         }
 
-        // We only care about saving owners, requireVersion, params, and suffixes
+        // We only care about saving owners, params, and suffixes
         pixelParent[lastPart][ROOT_PREFIX] = {};
         pixelParent[lastPart][ROOT_PREFIX].owners = pixelDefs[prefix].owners;
-        pixelParent[lastPart][ROOT_PREFIX].requireVersion = pixelDefs[prefix].requireVersion;
         pixelParent[lastPart][ROOT_PREFIX].parameters = pixelDefs[prefix].parameters;
         pixelParent[lastPart][ROOT_PREFIX].suffixes = pixelDefs[prefix].suffixes;
     }

--- a/tests/integration_test.mjs
+++ b/tests/integration_test.mjs
@@ -157,8 +157,9 @@ describe('Validate pixel debug logs', () => {
 
             // Check errors
             const expectedErrors = [
-                `❌ Invalid: 'm_my_first_pixel?extraParam=hello' - see below for details`,
+                `❌ Invalid: 'm_my_first_pixel?extraParam=hello&appVersion=2.0.3' - see below for details`,
                 `\tmust NOT have additional properties. Found extra property 'extraParam'`,
+                "⚠️  Old app version, validation skipped: 'm_my_first_pixel?count=42&date=2025-03-12'",
                 "⚠️  Old app version, validation skipped: 'm_my_first_pixel?count=42&date=2025-03-12&appVersion=0.0.1'",
                 "⚠️  Undocumented: 'unknown-pixel'",
             ];
@@ -182,6 +183,7 @@ describe('Validate pixel debug logs', () => {
 
             // Check errors
             const expectedErrors = [
+                "⚠️  Old app version, validation skipped: 'm_my_first_pixel'",
                 `❌ Invalid: 'experiment_enroll_defaultBrowser_control?extraParam=20' - see below for details`,
                 `\tmust NOT have additional properties. Found extra property 'extraParam'`,
                 "⚠️  Undocumented: 'experiment_enroll_x'",
@@ -190,9 +192,8 @@ describe('Validate pixel debug logs', () => {
             expect(errors).to.include.members(expectedErrors);
 
             // Check regular output
-            const expectedLogs = ["✅ Valid: 'm_my_first_pixel'"];
             const logs = stdout.trim().split('\n');
-            expect(logs).to.include.members(expectedLogs);
+            expect(logs).to.not.include("✅ Valid: 'm_my_first_pixel'");
 
             done();
         });

--- a/tests/live_pixel_validation_test.mjs
+++ b/tests/live_pixel_validation_test.mjs
@@ -346,6 +346,15 @@ describe('App version outdated', () => {
         expect(pixelStatus.errors).to.be.empty;
     });
 
+    it('missing app version should return OLD_APP_VERSION status by default', () => {
+        const prefix = 'versionedPixel';
+        const params = 'param1=test';
+        const pixelStatus = liveValidator.validatePixel(prefix, params);
+
+        expect(pixelStatus.status).to.equal(PIXEL_VALIDATION_RESULT.OLD_APP_VERSION);
+        expect(pixelStatus.errors).to.be.empty;
+    });
+
     it('current app version should pass validation', () => {
         const prefix = 'versionedPixel';
         const params = 'appVersion=2.0.0&param1=test';
@@ -469,7 +478,42 @@ describe('Case-insensitive suffix shortcut resolution', () => {
     });
 });
 
-describe('Require version', () => {
+describe('Require version defaults', () => {
+    const productDefWithVersion = {
+        target: {
+            key: 'appVersion',
+            version: '2.0.0',
+        },
+        agents: [],
+        forceLowerCase: false,
+    };
+
+    const paramsValidator = new ParamsValidator({}, {}, {});
+    const pixelDefs = {
+        nonVersionedPixel: {
+            parameters: [
+                {
+                    key: 'param1',
+                    type: 'string',
+                },
+            ],
+        },
+    };
+    const tokenizedDefs = {};
+    tokenizePixelDefs(pixelDefs, tokenizedDefs);
+    const liveValidator = new LivePixelsValidator(tokenizedDefs, productDefWithVersion, {}, paramsValidator);
+
+    it('should not require app version when target key is not defined in the pixel params', () => {
+        const prefix = 'nonVersionedPixel';
+        const params = 'param1=test';
+        const pixelStatus = liveValidator.validatePixel(prefix, params);
+
+        expect(pixelStatus.status).to.equal(PIXEL_VALIDATION_RESULT.VALIDATION_PASSED);
+        expect(pixelStatus.errors).to.be.empty;
+    });
+});
+
+describe('Missing app version in versioned pixels', () => {
     const productDefWithVersion = {
         target: {
             key: 'appVersion',
@@ -482,7 +526,6 @@ describe('Require version', () => {
     const paramsValidator = new ParamsValidator({}, {}, {});
     const pixelDefs = {
         versionRequiredPixel: {
-            requireVersion: true,
             parameters: [
                 {
                     key: 'appVersion',
@@ -499,7 +542,7 @@ describe('Require version', () => {
     tokenizePixelDefs(pixelDefs, tokenizedDefs);
     const liveValidator = new LivePixelsValidator(tokenizedDefs, productDefWithVersion, {}, paramsValidator);
 
-    it('should return OLD_APP_VERSION status if version param is missing when required', () => {
+    it('should return OLD_APP_VERSION status if app version param is missing', () => {
         const prefix = 'versionRequiredPixel';
         const params = 'param1=test';
         const pixelStatus = liveValidator.validatePixel(prefix, params);
@@ -508,7 +551,7 @@ describe('Require version', () => {
         expect(pixelStatus.errors).to.be.empty;
     });
 
-    it('should proceed with validation if version param is present when required', () => {
+    it('should proceed with validation if app version param is present', () => {
         const prefix = 'versionRequiredPixel';
         const params = 'appVersion=2.0.0&param1=test';
         const pixelStatus = liveValidator.validatePixel(prefix, params);

--- a/tests/query_window_integration_test.mjs
+++ b/tests/query_window_integration_test.mjs
@@ -10,7 +10,6 @@ describe('queryWindowInDays integration', () => {
     it('skips version checks when product.json only has queryWindowInDays', () => {
         const pixelDefs = {
             versionRequiredPixel: {
-                requireVersion: true,
                 parameters: [
                     {
                         key: 'appVersion',
@@ -23,19 +22,19 @@ describe('queryWindowInDays integration', () => {
                 ],
             },
         };
-        const tokenized = buildTokenizedPixels([pixelDefs]);
-
         // Test only queryWindowInDays
+        const queryWindowTokenized = buildTokenizedPixels([pixelDefs]);
         const productDefPath = path.join('tests', 'test_data', 'query_window', 'product.json');
         const queryWindowDef = JSON5.parse(fs.readFileSync(productDefPath));
-        const queryWindowValidator = buildLivePixelValidator({}, {}, queryWindowDef, {}, tokenized);
+        const queryWindowValidator = buildLivePixelValidator({}, {}, queryWindowDef, {}, queryWindowTokenized);
         const queryWindowResult = queryWindowValidator.validatePixel('versionRequiredPixel', 'param1=test');
 
         // Test queryWindowInDays + version
+        const versionTokenized = buildTokenizedPixels([pixelDefs]);
         const productDefWithVersion = JSON.parse(JSON.stringify(queryWindowDef));
         productDefWithVersion.target.version = '2.0.0';
         productDefWithVersion.target.key = 'appVersion';
-        const versionValidator = buildLivePixelValidator({}, {}, productDefWithVersion, {}, tokenized);
+        const versionValidator = buildLivePixelValidator({}, {}, productDefWithVersion, {}, versionTokenized);
         const versionResult = versionValidator.validatePixel('versionRequiredPixel', 'appVersion=1.0.0&param1=test');
 
         expect(versionResult.status).to.equal(PIXEL_VALIDATION_RESULT.OLD_APP_VERSION);

--- a/tests/test_data/valid/pixels/pixel_debug_log.txt
+++ b/tests/test_data/valid/pixels/pixel_debug_log.txt
@@ -1,10 +1,11 @@
-﻿Sample log file that mimics Android and Windows log formats
+Sample log file that mimics Android and Windows log formats
 -----------------------------------------------------------
 Android example below:
 --------- beginning of main
 Pixel url request: https://improving.duckduckgo.com/t/unknown-pixel
 Pixel url request: https://improving.duckduckgo.com/t/m_my_first_pixel?count=42&date=2025-03-12&appVersion=2.0.3
-Pixel url request: https://improving.duckduckgo.com/t/m_my_first_pixel?extraParam=hello
+Pixel url request: https://improving.duckduckgo.com/t/m_my_first_pixel?extraParam=hello&appVersion=2.0.3
+Pixel url request: https://improving.duckduckgo.com/t/m_my_first_pixel?count=42&date=2025-03-12
 Pixel url request: https://improving.duckduckgo.com/t/m_my_first_pixel?count=42&date=2025-03-12&appVersion=0.0.1
 -----------------------------------------------------------
 Windows example below:

--- a/tests/test_data/valid/pixels/test_live_pixels.csv
+++ b/tests/test_data/valid/pixels/test_live_pixels.csv
@@ -5,14 +5,15 @@ m.my.first.pixel.test,[],
 m.my.first.pixel.test,['expValidA=a'],
 m.my.first.pixel.test,['extraParam=10'],
 m.my.first.pixel.test.extra-suffix,[],
-m.my.first.pixel.unexpected-suffix,[],
-m.my.first.pixel.new.unexpected-suffix2,[],
-m.my.first.pixel.new.exceptiontype.some-exception.unexpected-suffix3,[],
-m.my.first.pixel.new.exceptiontype.x.android.unexpected-4,[],
+m.my.first.pixel.unexpected-suffix,[],appVersion=2.0.3
+m.my.first.pixel.new.unexpected-suffix2,[],appVersion=2.0.3
+m.my.first.pixel.new.exceptiontype.some-exception.unexpected-suffix3,[],appVersion=2.0.3
+m.my.first.pixel.new.exceptiontype.x.android.unexpected-4,[],appVersion=2.0.3
 m.my.first.pixel.new.exceptiontype.x.android.phone,[],appVersion=wrongFormat
 m.my.first.pixel.skip-due-to-version,"['count=unexpectedButSkip']",appVersion=0.0
 m.my.first.pixel,"['count=wrongFormat']",appVersion=2.0.0
 m.my.first.pixel,"['count=42', 'date=2025-03-12']",appVersion=2.0.3
+m.my.first.pixel,['count=42'],
 experiment.enroll.defaultBrowser.control,"['enrollmentDate=2025-04-22', 'conversionWindowDays=8-15']",
 experiment.enroll.defaultBrowser.control,"['enrollmentDate=not_a_date', 'conversionWindowDays=x-x-x']",
 experiment.enroll.x,[],


### PR DESCRIPTION
Task: https://app.asana.com/1/137249556945/project/1209805270658160/task/1213798672517235?focus=true

I verified this branch vs main (same CSV) for iOS, Mac and Windows.  Any differences noted were as expected:
- errors no longer present were for pixels where app version was specified but not present in the request
- no new errors were introduced


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live pixel validation behavior by treating missing app version as `OLD_APP_VERSION` whenever the pixel definition includes the target version key, which can alter validation outcomes and downstream reporting.
> 
> **Overview**
> Updates live pixel validation to **skip validation as `OLD_APP_VERSION` when the product target version is configured and the matched pixel definition includes the target version parameter but the live pixel instance omits it** (removing the per-pixel `requireVersion` flag).
> 
> Removes `requireVersion` from the pixel JSON schema, tokenizer, and docs, and adjusts/extends integration + unit tests and sample log/CSV fixtures to reflect the new default behavior for versioned vs non-versioned pixels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e151ad023467dd37cea40d269da0d323056a1ac8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->