### PR TITLE
Add 'is_triggering' optional property to the Search Experiments schema

### DIFF
--- a/schemas/search_experiments_schema.json5
+++ b/schemas/search_experiments_schema.json5
@@ -42,7 +42,11 @@
                     "type": "array",
                     "items": { "type": "string" }
                 },
-                "exclusionGroup": { "type": "string" }
+                "exclusionGroup": { "type": "string" },
+                "is_triggering": {
+                    "description": "Whether this experiment impacts Instant Answer triggering",
+                    "type": "boolean"
+                }
             }
         }
     }

--- a/tests/test_data/valid/pixels/search_experiments.json
+++ b/tests/test_data/valid/pixels/search_experiments.json
@@ -5,7 +5,8 @@
         "assignment": "backend_spu",
         "persistent": false,
         "variants": ["a", "b"],
-        "services": ["deep"]
+        "services": ["deep"],
+        "is_triggering": true
     },
     "expValidB": {
         "allocation": 1.0,


### PR DESCRIPTION
Asana task: https://app.asana.com/1/137249556945/project/1212446972456925/task/1213825502072693?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema/test-data update that only adds a new optional boolean field; main risk is downstream consumers rejecting/ignoring the new property if they assume a fixed set of keys.
> 
> **Overview**
> Adds an optional `is_triggering` boolean to `schemas/search_experiments_schema.json5` to indicate whether an experiment affects Instant Answer triggering.
> 
> Updates the corresponding valid fixture (`tests/test_data/valid/pixels/search_experiments.json`) to include `is_triggering: true` for one experiment to cover schema validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e22884f888cb4af72834824cc4481901c2871de1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->