### PR TITLE
Report unused pixel defs

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ To avoid having to put your pixel defintions on a dev node and setup there, simp
 
 4. Validate: `./scripts/revalidateRepo.sh <Path to your client repo's PixelDefintions>`
 5. Review errors in `<Path to your client repo's PixelDefintions/pixels/pixel_processing_results/>`
+    * `pixel_errors.json`: documented pixels that failed validation
+    * `undocumented_pixels.json`: live pixels with no matching definition
+    * `unused_pixel_definitions.json`: defined pixel names not seen during live validation (name only, suffix/params ignored; excludes `native_experiments.json`)
 
 As needed, you can re-run step 4 and step 5 after updating your definitions.
 

--- a/live_validation_scripts/validate_live_pixel.mjs
+++ b/live_validation_scripts/validate_live_pixel.mjs
@@ -57,12 +57,18 @@ async function main(mainDir, csvFile) {
             saveResult(pixelRequestFormat, result);
         })
         .on('end', async () => {
+            const unusedPixelDefinitions = liveValidator.getUnusedPixelNames();
             console.log(`\nDone.\nTotal pixels processed: ${processedPixels.toLocaleString('en-US')}`);
             console.log(`Undocumented pixels: ${undocumentedPixels.size.toLocaleString('en-US')}`);
             console.log(`Pixels with validation errors: ${Object.keys(pixelErrors).length.toLocaleString('en-US')}`);
+            console.log(`Unused pixel definitions: ${unusedPixelDefinitions.length.toLocaleString('en-US')}`);
+            if (unusedPixelDefinitions.length > 0) {
+                console.log(`Unused pixel definition names: ${unusedPixelDefinitions.join(', ')}`);
+            }
 
             fs.writeFileSync(fileUtils.getUndocumentedPixelsPath(pixelsConfigDir), JSON.stringify(Array.from(undocumentedPixels), null, 4));
             fs.writeFileSync(fileUtils.getPixelErrorsPath(pixelsConfigDir), JSON.stringify(pixelErrors, setReplacer, 4));
+            fs.writeFileSync(fileUtils.getUnusedPixelDefinitionsPath(pixelsConfigDir), JSON.stringify(unusedPixelDefinitions, null, 4));
             console.log(`Validation results saved to ${fileUtils.getResultsDir(pixelsConfigDir)}`);
         });
 }

--- a/schemas/pixel_schema.json5
+++ b/schemas/pixel_schema.json5
@@ -13,7 +13,7 @@
                 },
                 {
                     "type": "string",
-                    "pattern": ".*\\..*" // `.` not allowed - pixel names must use `_` instead
+                    "pattern": "[^a-z0-9_-]+" // expect '_' for '.', otherwise only '-', lowercase alpha and numbers
                 }
             ]
         }

--- a/schemas/wide_event_schema.json5
+++ b/schemas/wide_event_schema.json5
@@ -292,6 +292,28 @@
             },
             "additionalProperties": false
         },
+        "journeySchemaProperty": {
+            "type": "object",
+            "description": "JSON Schema for the journey section",
+            "required": ["type", "required", "additionalProperties", "properties"],
+            "properties": {
+                "type": { "const": "object" },
+                "required": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                },
+                "additionalProperties": { "const": false },
+                "properties": {
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                        "name": { "$ref": "#/$defs/stringEnumProperty" }
+		            },
+		            "additionalProperties": false
+		        }
+	        },
+	        "additionalProperties": false
+        },
 
         // The main wide event schema definition
         // This is a JSON Schema that validates wide event data
@@ -334,7 +356,8 @@
                         "app": { "$ref": "#/$defs/appSchemaProperty" },
                         "global": { "$ref": "#/$defs/globalSchemaProperty" },
                         "feature": { "$ref": "#/$defs/featureSchemaProperty" },
-                        "context": { "$ref": "#/$defs/contextSchemaProperty" }
+                        "context": { "$ref": "#/$defs/contextSchemaProperty" },
+                        "journey": { "$ref": "#/$defs/journeySchemaProperty" }
                     }
                 }
             }

--- a/src/error_utils.mjs
+++ b/src/error_utils.mjs
@@ -32,7 +32,8 @@ function formatAjvErrors(validationErrors, suffixes = null) {
 
             if (error.message === 'property name must be valid') {
                 formattedError = `Invalid property name '${error.params.propertyName}'. If this is a pixel:`;
-                formattedError += `\n\t* pixel names must not contain '.' --> use '_' instead`;
+                formattedError += `\n\t* pixel names must only contain lowercase alpha, numbers, and '_' & '-' ( [a-z0-9_-] )`;
+                formattedError += `\n\t* for pixel delimiter use '_' instead of '.'`;
                 formattedError += `\n\t* experiments must be defined in the 'native_experiments.json' file`;
             }
         }

--- a/src/file_utils.mjs
+++ b/src/file_utils.mjs
@@ -183,6 +183,15 @@ export function getUndocumentedPixelsPath(mainPixelDir) {
 }
 
 /**
+ * Get path to unused pixel definitions encountered during live validation
+ * @param {string} mainPixelDir - path to the main pixels directory
+ * @returns {string} unused pixel definitions path
+ */
+export function getUnusedPixelDefinitionsPath(mainPixelDir) {
+    return getResultsFilePath(mainPixelDir, 'unused_pixel_definitions.json');
+}
+
+/**
  * Get tokenized pixels path
  * @param {string} mainPixelDir - path to the main pixels directory
  * @returns {string} tokenized pixels path

--- a/src/live_pixel_validator.mjs
+++ b/src/live_pixel_validator.mjs
@@ -16,6 +16,8 @@ export class LivePixelsValidator {
     #defsVersion;
     #defsVersionKey;
     #forceLowerCase;
+    #definedPixelNames;
+    #usedPixelNames;
 
     #commonExperimentParamsSchema;
     #commonExperimentSuffixesSchema;
@@ -32,6 +34,7 @@ export class LivePixelsValidator {
     constructor(tokenizedPixels, productDef, experimentsDef, paramsValidator) {
         this.#initPixelState();
         this.#forceLowerCase = productDef.forceLowerCase;
+        this.#usedPixelNames = new Set();
         // version should be resolved before constructing validator (via resolveTargetVersion)
         if (productDef.target.version) {
             this.#defsVersion = this.#getNormalizedVal(productDef.target.version);
@@ -58,6 +61,8 @@ export class LivePixelsValidator {
             experimentDef.metrics.app_use = defaultsSchema;
             experimentDef.metrics.search = defaultsSchema;
         });
+
+        this.#definedPixelNames = this.#collectDefinedPixelNames(tokenizedPixels);
     }
 
     /**
@@ -181,6 +186,58 @@ export class LivePixelsValidator {
     }
 
     /**
+     * Builds a list of all defined pixel names.
+     * Includes only regular pixel definitions from the `pixels/definitions` files.
+     *
+     * @param {object} tokenizedPixels tokenized regular pixel definitions.
+     * @returns {Set<string>} all pixel definition names.
+     */
+    #collectDefinedPixelNames(tokenizedPixels) {
+        const names = new Set();
+
+        const walkTokenizedDefs = (node, prefix = '') => {
+            Object.entries(node).forEach(([key, value]) => {
+                if (key === ROOT_PREFIX) {
+                    if (prefix) {
+                        names.add(prefix);
+                    }
+                    return;
+                }
+                const nextPrefix = prefix ? `${prefix}${PIXEL_DELIMITER}${key}` : key;
+                walkTokenizedDefs(value, nextPrefix);
+            });
+        };
+
+        walkTokenizedDefs(tokenizedPixels);
+
+        return names;
+    }
+
+    /**
+     * Returns all defined pixel names, sorted alphabetically.
+     * @returns {string[]} list of all pixel definition names.
+     */
+    getDefinedPixelNames() {
+        return Array.from(this.#definedPixelNames).sort();
+    }
+
+    /**
+     * Returns all used pixel names, sorted alphabetically.
+     * @returns {string[]} list of used pixel definition names.
+     */
+    getUsedPixelNames() {
+        return Array.from(this.#usedPixelNames).sort();
+    }
+
+    /**
+     * Returns pixel definition names that were never matched during validation.
+     * @returns {string[]} list of unused pixel definition names.
+     */
+    getUnusedPixelNames() {
+        return this.getDefinedPixelNames().filter((pixelName) => !this.#usedPixelNames.has(pixelName));
+    }
+
+    /**
      * Validates a native experiment pixel name and parameters.
      * @param {string} pixel full pixel name.
      * @param {string} paramsUrlFormat query string without cache buster.
@@ -209,6 +266,7 @@ export class LivePixelsValidator {
             this.#saveErrors(pixelPrefix, pixel, [`Unknown experiment '${experimentName}'`]);
             return this.#currentPixelState;
         }
+        this.#usedPixelNames.add(pixelPrefix);
 
         // Check cohort
         const cohortName = pixelParts[2];
@@ -279,6 +337,7 @@ export class LivePixelsValidator {
         // TODO: experiments don't have owners. Fix in https://app.asana.com/1/137249556945/project/1209805270658160/task/1210955210382823?focus=true
         this.#currentPixelState.owners = pixelMatch.owners;
         this.#currentPixelState.requireVersion = pixelMatch.requireVersion;
+        this.#usedPixelNames.add(prefix);
 
         this.validatePixelParamsAndSuffixes(prefix, pixel, params, pixelMatch);
         return this.#currentPixelState;

--- a/tests/integration_test.mjs
+++ b/tests/integration_test.mjs
@@ -116,6 +116,14 @@ describe('Validate live pixels', () => {
                 );
                 expect(undocumentedPixels).to.deep.equal(expectedUndocumented);
 
+                const unusedPixelDefinitions = JSON5.parse(
+                    fs.readFileSync(fileUtils.getUnusedPixelDefinitionsPath(path.join(validDefsPath, 'pixels'))).toString(),
+                );
+                const expectedUnusedDefinitions = JSON5.parse(
+                    fs.readFileSync(path.join(liveValidationResultsPath, 'unused_pixel_definitions.json')).toString(),
+                );
+                expect(unusedPixelDefinitions).to.deep.equal(expectedUnusedDefinitions);
+
                 done();
             });
         });
@@ -140,6 +148,11 @@ describe('Validate live pixels', () => {
                         fs.readFileSync(fileUtils.getUndocumentedPixelsPath(path.join(validCaseInsensitiveDefsPath, 'pixels'))).toString(),
                     );
                     expect(undocumentedPixels).to.be.empty;
+
+                    const unusedPixelDefinitions = JSON5.parse(
+                        fs.readFileSync(fileUtils.getUnusedPixelDefinitionsPath(path.join(validCaseInsensitiveDefsPath, 'pixels'))).toString(),
+                    );
+                    expect(unusedPixelDefinitions).to.be.empty;
 
                     done();
                 },

--- a/tests/live_pixel_validation_test.mjs
+++ b/tests/live_pixel_validation_test.mjs
@@ -569,3 +569,44 @@ describe('Key pattern parameters with explicit types', () => {
         expect(pixelStatus.errors.map((e) => e.example)).to.have.members([params]);
     });
 });
+
+describe('Used and unused pixel definition tracking', () => {
+    const paramsValidator = new ParamsValidator({}, {}, {});
+    const pixelDefs = {
+        tracked_pixel: {
+            description: 'tracked pixel',
+            owners: ['tester'],
+            triggers: ['other'],
+            suffixes: [
+                {
+                    enum: ['a', 'b'],
+                },
+            ],
+        },
+        never_seen_pixel: {
+            description: 'unused pixel',
+            owners: ['tester'],
+            triggers: ['other'],
+        },
+    };
+    const tokenizedDefs = {};
+    tokenizePixelDefs(pixelDefs, tokenizedDefs);
+    const experimentsDef = {
+        activeExperiments: {
+            expA: {
+                cohorts: ['control'],
+                metrics: {},
+            },
+        },
+    };
+    const liveValidator = new LivePixelsValidator(tokenizedDefs, productDef, experimentsDef, paramsValidator);
+
+    it('tracks usage by pixel name only and reports unused regular definitions', () => {
+        liveValidator.validatePixel(`tracked${PIXEL_DELIMITER}pixel${PIXEL_DELIMITER}a`, '');
+        liveValidator.validatePixel(`tracked${PIXEL_DELIMITER}pixel${PIXEL_DELIMITER}b`, '');
+        liveValidator.validatePixel(`experiment${PIXEL_DELIMITER}metrics${PIXEL_DELIMITER}expA${PIXEL_DELIMITER}control`, 'metric=app_use&value=1');
+
+        expect(liveValidator.getUsedPixelNames()).to.include.members(['experiment_metrics_expA', 'tracked_pixel']);
+        expect(liveValidator.getUnusedPixelNames()).to.deep.equal(['never_seen_pixel']);
+    });
+});

--- a/tests/pixel_definition_validation_test.mjs
+++ b/tests/pixel_definition_validation_test.mjs
@@ -1,4 +1,9 @@
 import { expect } from 'chai';
+import Ajv2020 from 'ajv/dist/2020.js';
+import fs from 'fs';
+import JSON5 from 'json5';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 import { PixelDefinitionsValidator, WideEventDefinitionsValidator } from '../src/definitions_validator.mjs';
 import { ParamsValidator } from '../src/params_validator.mjs';
@@ -1322,5 +1327,83 @@ describe('Wide Event required fields follow metaschema', () => {
         expect(generated.properties.global.required).to.deep.equal(['platform', 'type', 'sample_rate']);
         expect(generated.properties.feature.required).to.deep.equal(['name', 'status', 'data']);
         expect(generated.properties.context.required).to.deep.equal(['name']);
+    });
+});
+
+describe('Wide Event metaschema section definitions', () => {
+    const schemasPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'schemas');
+    const wideEventSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'wide_event_schema.json5')).toString());
+    const propSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'prop_schema.json5')).toString());
+
+    // eslint-disable-next-line new-cap
+    const ajv = new Ajv2020.default({ allErrors: true });
+    ajv.addSchema(propSchema);
+
+    const contextSchemaValidator = ajv.compile({
+        $ref: '#/$defs/contextSchemaProperty',
+        $defs: wideEventSchema.$defs,
+    });
+
+    const journeySchemaValidator = ajv.compile({
+        $ref: '#/$defs/journeySchemaProperty',
+        $defs: wideEventSchema.$defs,
+    });
+
+    it('accepts a valid contextSchemaProperty section', () => {
+        const validContextSection = {
+            type: 'object',
+            required: ['name'],
+            additionalProperties: false,
+            properties: {
+                name: {
+                    type: 'string',
+                    description: 'Context name',
+                    enum: ['onboarding', 'settings'],
+                },
+            },
+        };
+
+        expect(contextSchemaValidator(validContextSection)).to.be.true;
+    });
+
+    it('rejects an invalid contextSchemaProperty section', () => {
+        const invalidContextSection = {
+            type: 'object',
+            required: ['name'],
+            additionalProperties: false,
+            properties: {},
+        };
+
+        expect(contextSchemaValidator(invalidContextSection)).to.be.false;
+        expect(contextSchemaValidator.errors?.some((error) => error.message?.includes("must have required property 'name'"))).to.be.true;
+    });
+
+    it('accepts a valid journeySchemaProperty section', () => {
+        const validJourneySection = {
+            type: 'object',
+            required: ['name'],
+            additionalProperties: false,
+            properties: {
+                name: {
+                    type: 'string',
+                    description: 'Journey name',
+                    enum: ['first_run', 'returning_user'],
+                },
+            },
+        };
+
+        expect(journeySchemaValidator(validJourneySection)).to.be.true;
+    });
+
+    it('rejects an invalid journeySchemaProperty section', () => {
+        const invalidJourneySection = {
+            type: 'object',
+            required: ['name'],
+            additionalProperties: false,
+            properties: {},
+        };
+
+        expect(journeySchemaValidator(invalidJourneySection)).to.be.false;
+        expect(journeySchemaValidator.errors?.some((error) => error.message?.includes("must have required property 'name'"))).to.be.true;
     });
 });

--- a/tests/test_data/valid/pixels/expected_processing_results/unused_pixel_definitions.json
+++ b/tests/test_data/valid/pixels/expected_processing_results/unused_pixel_definitions.json
@@ -1,0 +1,5 @@
+[
+    "test_suffixes",
+    "test_tokenizer",
+    "test_tokenizer_3_level_deep"
+]


### PR DESCRIPTION
Task: https://app.asana.com/1/137249556945/project/1209805270658160/task/1211905648211487?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new output/reporting to live pixel validation and expands the wide event metaschema with a new `journey` section, which could change validation results and downstream expectations for generated schemas.
> 
> **Overview**
> Live pixel validation now **tracks which pixel definition names are actually matched** during a run and emits a new report file, `unused_pixel_definitions.json`, alongside existing `pixel_errors.json` and `undocumented_pixels.json`.
> 
> `LivePixelsValidator` collects all defined pixel names from tokenized definitions, records matched prefixes for both regular pixels and native experiment prefixes, and exposes `getUnusedPixelNames()`; the CLI (`validate_live_pixel.mjs`) logs counts and writes the new results file.
> 
> The wide event metaschema is extended to allow an optional `journey` section (`journeySchemaProperty`), and tests are updated/added to validate the new metaschema fragment and the new live-validation output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f67927c93df3582dcd8a1278f2b0359a5bdf4138. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->