### PR TITLE
v2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@duckduckgo/pixel-schema",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@duckduckgo/pixel-schema",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/node": "^24.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@duckduckgo/pixel-schema",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "files": [
         "main.mjs",
         "bin",


### PR DESCRIPTION
Bump version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change with no functional or dependency updates, so behavioral risk is minimal.
> 
> **Overview**
> Bumps the `@duckduckgo/pixel-schema` package version from `2.1.0` to `2.1.1` in both `package.json` and `package-lock.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 621ee010b4df9d1125272ccde1bcedbc3a41f8d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->