### PR TITLE
Wide event schema updates

### DIFF
--- a/Jenkinsfiles/Jenkinsfile.dev
+++ b/Jenkinsfiles/Jenkinsfile.dev
@@ -36,7 +36,7 @@ pipeline {
             steps {
                 dir('pixel-schema') {
                     checkout([$class: 'GitSCM', branches: [[name: "${params.PIXEL_SCHEMA_BRANCH}"]],
-                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout'], [$class: 'PruneStaleBranch']],
                     userRemoteConfigs: [[url: 'https://github.com/duckduckgo/pixel-schema.git']]])
                 }
             }
@@ -60,7 +60,7 @@ pipeline {
 
                     dir('client-repo') {
                         checkout([$class: 'GitSCM', branches: [[name: "${params.CLIENT_BRANCH}"]],
-                            extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
+                            extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout'], [$class: 'PruneStaleBranch']],
                             userRemoteConfigs: [[credentialsId: 'windows-browser-rw', url: "https://github.com/duckduckgo/${clientRepo}.git"]]] )
                     }
                 }
@@ -70,7 +70,7 @@ pipeline {
             steps {
                 dir('internal-github-asana-utils') {
                     checkout([$class: 'GitSCM', branches: [[name: "main"]],
-                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout'], [$class: 'PruneStaleBranch']],
                     userRemoteConfigs: [[credentialsId: 'windows-browser-rw', url: 'https://github.com/duckduckgo/internal-github-asana-utils.git']]])
                 }
             }

--- a/Jenkinsfiles/Jenkinsfile.dev
+++ b/Jenkinsfiles/Jenkinsfile.dev
@@ -36,7 +36,7 @@ pipeline {
             steps {
                 dir('pixel-schema') {
                     checkout([$class: 'GitSCM', branches: [[name: "${params.PIXEL_SCHEMA_BRANCH}"]],
-                    extensions: [[$class: 'LocalBranch']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
                     userRemoteConfigs: [[url: 'https://github.com/duckduckgo/pixel-schema.git']]])
                 }
             }
@@ -60,7 +60,7 @@ pipeline {
 
                     dir('client-repo') {
                         checkout([$class: 'GitSCM', branches: [[name: "${params.CLIENT_BRANCH}"]],
-                            extensions: [[$class: 'LocalBranch']],
+                            extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
                             userRemoteConfigs: [[credentialsId: 'windows-browser-rw', url: "https://github.com/duckduckgo/${clientRepo}.git"]]] )
                     }
                 }
@@ -70,7 +70,7 @@ pipeline {
             steps {
                 dir('internal-github-asana-utils') {
                     checkout([$class: 'GitSCM', branches: [[name: "main"]],
-                    extensions: [[$class: 'LocalBranch']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
                     userRemoteConfigs: [[credentialsId: 'windows-browser-rw', url: 'https://github.com/duckduckgo/internal-github-asana-utils.git']]])
                 }
             }

--- a/Jenkinsfiles/Jenkinsfile.params
+++ b/Jenkinsfiles/Jenkinsfile.params
@@ -77,7 +77,7 @@ pipeline {
             steps {
                 dir('pixel-schema') {
                     checkout([$class: 'GitSCM', branches: [[name: "${params.PIXEL_SCHEMA_BRANCH}"]],
-                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout'], [$class: 'PruneStaleBranch']],
                     userRemoteConfigs: [[url: 'https://github.com/duckduckgo/pixel-schema.git']]])
                 }
             }
@@ -89,7 +89,7 @@ pipeline {
             steps {
                 dir('duckduckgo-privacy-extension') {
                     checkout([$class: 'GitSCM', branches: [[name: "${params.EXTENSION_BRANCH}"]],
-                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout'], [$class: 'PruneStaleBranch']],
                     userRemoteConfigs: [[url: 'https://github.com/duckduckgo/duckduckgo-privacy-extension.git']]])
                 }
             }
@@ -101,7 +101,7 @@ pipeline {
             steps {
                 dir('windows-browser') {
                     checkout([$class: 'GitSCM', branches: [[name: "${params.WINDOWS_BROWSER_BRANCH}"]],
-                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout'], [$class: 'PruneStaleBranch']],
                     userRemoteConfigs: [[credentialsId: 'windows-browser-rw', url: 'https://github.com/duckduckgo/windows-browser.git']]])
                 }
             }
@@ -113,7 +113,7 @@ pipeline {
             steps {
                 dir('apple-browsers') {
                     checkout([$class: 'GitSCM', branches: [[name: "${params.APPLE_BROWSERS_BRANCH}"]],
-                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout'], [$class: 'PruneStaleBranch']],
                     userRemoteConfigs: [[url: 'https://github.com/duckduckgo/apple-browsers.git']]])
                 }
             }
@@ -125,7 +125,7 @@ pipeline {
             steps {
                 dir('android') {
                     checkout([$class: 'GitSCM', branches: [[name: "${params.ANDROID_BRANCH}"]],
-                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout'], [$class: 'PruneStaleBranch']],
                     userRemoteConfigs: [[url: 'https://github.com/duckduckgo/android.git']]])
                 }
             }
@@ -134,7 +134,7 @@ pipeline {
             steps {
                 dir('internal-github-asana-utils') {
                     checkout([$class: 'GitSCM', branches: [[name: "${params.ASANA_UTILS_BRANCH}"]],
-                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout'], [$class: 'PruneStaleBranch']],
                     userRemoteConfigs: [[credentialsId: 'windows-browser-rw', url: 'https://github.com/duckduckgo/internal-github-asana-utils.git']]])
                 }
             }

--- a/Jenkinsfiles/Jenkinsfile.params
+++ b/Jenkinsfiles/Jenkinsfile.params
@@ -77,7 +77,7 @@ pipeline {
             steps {
                 dir('pixel-schema') {
                     checkout([$class: 'GitSCM', branches: [[name: "${params.PIXEL_SCHEMA_BRANCH}"]],
-                    extensions: [[$class: 'LocalBranch']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
                     userRemoteConfigs: [[url: 'https://github.com/duckduckgo/pixel-schema.git']]])
                 }
             }
@@ -89,7 +89,7 @@ pipeline {
             steps {
                 dir('duckduckgo-privacy-extension') {
                     checkout([$class: 'GitSCM', branches: [[name: "${params.EXTENSION_BRANCH}"]],
-                    extensions: [[$class: 'LocalBranch']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
                     userRemoteConfigs: [[url: 'https://github.com/duckduckgo/duckduckgo-privacy-extension.git']]])
                 }
             }
@@ -101,7 +101,7 @@ pipeline {
             steps {
                 dir('windows-browser') {
                     checkout([$class: 'GitSCM', branches: [[name: "${params.WINDOWS_BROWSER_BRANCH}"]],
-                    extensions: [[$class: 'LocalBranch']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
                     userRemoteConfigs: [[credentialsId: 'windows-browser-rw', url: 'https://github.com/duckduckgo/windows-browser.git']]])
                 }
             }
@@ -113,7 +113,7 @@ pipeline {
             steps {
                 dir('apple-browsers') {
                     checkout([$class: 'GitSCM', branches: [[name: "${params.APPLE_BROWSERS_BRANCH}"]],
-                    extensions: [[$class: 'LocalBranch']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
                     userRemoteConfigs: [[url: 'https://github.com/duckduckgo/apple-browsers.git']]])
                 }
             }
@@ -125,7 +125,7 @@ pipeline {
             steps {
                 dir('android') {
                     checkout([$class: 'GitSCM', branches: [[name: "${params.ANDROID_BRANCH}"]],
-                    extensions: [[$class: 'LocalBranch']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
                     userRemoteConfigs: [[url: 'https://github.com/duckduckgo/android.git']]])
                 }
             }
@@ -134,7 +134,7 @@ pipeline {
             steps {
                 dir('internal-github-asana-utils') {
                     checkout([$class: 'GitSCM', branches: [[name: "${params.ASANA_UTILS_BRANCH}"]],
-                    extensions: [[$class: 'LocalBranch']],
+                    extensions: [[$class: 'LocalBranch'], [$class: 'CleanBeforeCheckout']],
                     userRemoteConfigs: [[credentialsId: 'windows-browser-rw', url: 'https://github.com/duckduckgo/internal-github-asana-utils.git']]])
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@duckduckgo/pixel-schema",
-    "version": "2.1.0",
+    "version": "2.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@duckduckgo/pixel-schema",
-            "version": "2.1.0",
+            "version": "2.1.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/node": "^24.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
             "version": "2.1.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "@types/node": "^24.12.0",
+                "@types/node": "^25.6.0",
                 "ajv": "^8.18.0",
                 "ajv-formats": "^3.0.1",
-                "asana": "^3.1.9",
+                "asana": "^3.1.11",
                 "compare-versions": "^6.1.1",
                 "csv-parser": "^3.2.0",
                 "js-yaml": "^4.1.1",
                 "json-schema-traverse": "^1.0.0",
                 "json5": "^2.2.3",
-                "typescript": "^5.9.3",
-                "yargs": "^17.7.2"
+                "typescript": "^6.0.3",
+                "yargs": "^18.0.0"
             },
             "bin": {
                 "validate-ddg-pixel-defs": "bin/validate_schema.mjs",
@@ -28,15 +28,15 @@
             },
             "devDependencies": {
                 "@duckduckgo/eslint-config": "github:duckduckgo/eslint-config#v0.1.0",
-                "@types/ajv": "^0.0.5",
+                "@types/ajv": "^1.0.4",
                 "@types/mocha": "^10.0.10",
-                "c8": "^10.1.3",
-                "chai": "^4.5.0",
+                "c8": "^11.0.0",
+                "chai": "^6.2.2",
                 "eslint": "^9.39.4",
                 "eslint-plugin-import": "^2.32.0",
-                "mocha": "^11.3.0",
-                "nock": "^14.0.11",
-                "prettier": "^3.8.1"
+                "mocha": "^11.7.5",
+                "nock": "^14.0.13",
+                "prettier": "^3.8.3"
             }
         },
         "node_modules/@babel/cli": {
@@ -73,6 +73,7 @@
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
             "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.28.5",
                 "js-tokens": "^4.0.0",
@@ -87,6 +88,7 @@
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
             "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -127,6 +129,7 @@
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
             "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.29.0",
                 "@babel/types": "^7.29.0",
@@ -143,6 +146,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
             "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/compat-data": "^7.28.6",
                 "@babel/helper-validator-option": "^7.27.1",
@@ -159,6 +163,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
             "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -168,6 +173,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
             "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/traverse": "^7.28.6",
                 "@babel/types": "^7.28.6"
@@ -181,6 +187,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
             "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.28.6",
                 "@babel/helper-validator-identifier": "^7.28.5",
@@ -198,6 +205,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
             "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -207,6 +215,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
             "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -216,6 +225,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
             "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -225,6 +235,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
             "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/template": "^7.28.6",
                 "@babel/types": "^7.28.6"
@@ -238,6 +249,7 @@
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
             "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.29.0"
             },
@@ -253,6 +265,7 @@
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
             "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.28.6",
                 "@babel/parser": "^7.28.6",
@@ -267,6 +280,7 @@
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
             "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -285,6 +299,7 @@
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
             "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
                 "@babel/helper-validator-identifier": "^7.28.5"
@@ -643,11 +658,10 @@
             }
         },
         "node_modules/@istanbuljs/schema": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+            "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -657,6 +671,7 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
             "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -667,6 +682,7 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
             "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -766,11 +782,14 @@
             "license": "MIT"
         },
         "node_modules/@types/ajv": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/@types/ajv/-/ajv-0.0.5.tgz",
-            "integrity": "sha512-0UD98SZLwPk6cTMZoLs8W4XSAWgqT9nyoZiBw+uXEPf1u5h+Dn2ztMG4Is9pDA+9D7GKbCTfIkQK/hNgoWVQcQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@types/ajv/-/ajv-1.0.4.tgz",
+            "integrity": "sha512-hq9s/qlTIJ2KYjs9MDt/ALvO7g/xIfGsVr2kjuNYLC52TieBkKAIQr7Fhk7jiQfmRXLQawY4nVgc/7wvxHow0g==",
+            "deprecated": "This is a stub types definition. ajv provides its own type definitions, so you do not need this installed.",
             "dev": true,
-            "license": "MIT"
+            "dependencies": {
+                "ajv": "*"
+            }
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
@@ -808,12 +827,11 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.12.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-            "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
-            "license": "MIT",
+            "version": "25.6.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+            "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
             "dependencies": {
-                "undici-types": "~7.16.0"
+                "undici-types": "~7.19.0"
             }
         },
         "node_modules/acorn": {
@@ -822,7 +840,6 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -877,6 +894,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -886,6 +904,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -1040,23 +1059,12 @@
             }
         },
         "node_modules/asana": {
-            "version": "3.1.9",
-            "resolved": "https://registry.npmjs.org/asana/-/asana-3.1.9.tgz",
-            "integrity": "sha512-X4AG1BpzGPg1VkyzDg1Il5O9ERdEd1QNTYxC48ODd+1IHndBByDsXyc1tKXYWAsJ62G7GSqlUVfMo4Q5UlSkdw==",
-            "license": "Apache 2.0",
+            "version": "3.1.11",
+            "resolved": "https://registry.npmjs.org/asana/-/asana-3.1.11.tgz",
+            "integrity": "sha512-NFSaiSdov8aEkGIc9DL3dlaKqkaLTDmm3fSuOF1bCAAsQ/d3bBC5xYKyJw6OBlEuYhkDAhgEJyxaxfueSCtf3Q==",
             "dependencies": {
                 "@babel/cli": "^7.0.0",
                 "superagent": "^6.1.0"
-            }
-        },
-        "node_modules/assertion-error": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/async-function": {
@@ -1102,6 +1110,7 @@
             "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
             "integrity": "sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
             },
@@ -1187,11 +1196,10 @@
             }
         },
         "node_modules/c8": {
-            "version": "10.1.3",
-            "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.3.tgz",
-            "integrity": "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/c8/-/c8-11.0.0.tgz",
+            "integrity": "sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.1",
                 "@istanbuljs/schema": "^0.1.3",
@@ -1200,7 +1208,7 @@
                 "istanbul-lib-coverage": "^3.2.0",
                 "istanbul-lib-report": "^3.0.1",
                 "istanbul-reports": "^3.1.6",
-                "test-exclude": "^7.0.1",
+                "test-exclude": "^8.0.0",
                 "v8-to-istanbul": "^9.0.0",
                 "yargs": "^17.7.2",
                 "yargs-parser": "^21.1.1"
@@ -1209,7 +1217,7 @@
                 "c8": "bin/c8.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": "20 || >=22"
             },
             "peerDependencies": {
                 "monocart-coverage-reports": "^2"
@@ -1218,6 +1226,55 @@
                 "monocart-coverage-reports": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/c8/node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/c8/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/c8/node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/call-bind": {
@@ -1309,25 +1366,16 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "CC-BY-4.0"
+            "license": "CC-BY-4.0",
+            "peer": true
         },
         "node_modules/chai": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-            "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "assertion-error": "^1.1.0",
-                "check-error": "^1.0.3",
-                "deep-eql": "^4.1.3",
-                "get-func-name": "^2.0.2",
-                "loupe": "^2.3.6",
-                "pathval": "^1.1.1",
-                "type-detect": "^4.1.0"
-            },
             "engines": {
-                "node": ">=4"
+                "node": ">=18"
             }
         },
         "node_modules/chalk": {
@@ -1345,19 +1393,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/check-error": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-            "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-func-name": "^2.0.2"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/chokidar": {
@@ -1386,23 +1421,69 @@
             }
         },
         "node_modules/cliui": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "license": "ISC",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+            "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
             "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
+                "string-width": "^7.2.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/cliui/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/cliui/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
+        },
+        "node_modules/cliui/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cliui/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
             },
             "engines": {
                 "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -1415,6 +1496,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/combined-stream": {
@@ -1582,19 +1664,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/deep-eql": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-            "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "type-detect": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1648,11 +1717,10 @@
             }
         },
         "node_modules/diff": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
-            "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+            "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
             }
@@ -1695,12 +1763,14 @@
             "version": "1.5.313",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
             "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/enhanced-resolve": {
@@ -1890,7 +1960,6 @@
             "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -2562,6 +2631,7 @@
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -2575,14 +2645,15 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
-        "node_modules/get-func-name": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-            "dev": true,
-            "license": "MIT",
+        "node_modules/get-east-asian-width": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+            "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
             "engines": {
-                "node": "*"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-intrinsic": {
@@ -3098,6 +3169,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -3194,6 +3266,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-path-inside": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-plain-obj": {
@@ -3466,7 +3547,8 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/js-yaml": {
             "version": "4.1.1",
@@ -3485,6 +3567,7 @@
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
             "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -3595,21 +3678,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/loupe": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-            "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-func-name": "^2.0.1"
-            }
-        },
         "node_modules/lru-cache": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "yallist": "^3.0.2"
             }
@@ -3720,29 +3794,29 @@
             }
         },
         "node_modules/mocha": {
-            "version": "11.3.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.3.0.tgz",
-            "integrity": "sha512-J0RLIM89xi8y6l77bgbX+03PeBRDQCOVQpnwOcCN7b8hCmbh6JvGI2ZDJ5WMoHz+IaPU+S4lvTd0j51GmBAdgQ==",
+            "version": "11.7.5",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+            "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "browser-stdout": "^1.3.1",
                 "chokidar": "^4.0.1",
                 "debug": "^4.3.5",
-                "diff": "^5.2.0",
+                "diff": "^7.0.0",
                 "escape-string-regexp": "^4.0.0",
                 "find-up": "^5.0.0",
                 "glob": "^10.4.5",
                 "he": "^1.2.0",
+                "is-path-inside": "^3.0.3",
                 "js-yaml": "^4.1.0",
                 "log-symbols": "^4.1.0",
-                "minimatch": "^5.1.6",
+                "minimatch": "^9.0.5",
                 "ms": "^2.1.3",
                 "picocolors": "^1.1.1",
                 "serialize-javascript": "^6.0.2",
                 "strip-json-comments": "^3.1.1",
                 "supports-color": "^8.1.1",
-                "workerpool": "^6.5.1",
+                "workerpool": "^9.2.0",
                 "yargs": "^17.7.2",
                 "yargs-parser": "^21.1.1",
                 "yargs-unparser": "^2.0.0"
@@ -3781,6 +3855,20 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/mocha/node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/mocha/node_modules/glob": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -3803,12 +3891,11 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+        "node_modules/mocha/node_modules/minimatch": {
             "version": "9.0.9",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
             "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.2"
             },
@@ -3817,19 +3904,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/mocha/node_modules/minimatch": {
-            "version": "5.1.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/mocha/node_modules/readdirp": {
@@ -3862,6 +3936,41 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
+        "node_modules/mocha/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/mocha/node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3876,11 +3985,10 @@
             "license": "MIT"
         },
         "node_modules/nock": {
-            "version": "14.0.11",
-            "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.11.tgz",
-            "integrity": "sha512-u5xUnYE+UOOBA6SpELJheMCtj2Laqx15Vl70QxKo43Wz/6nMHXS7PrEioXLjXAwhmawdEMNImwKCcPhBJWbKVw==",
+            "version": "14.0.13",
+            "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.13.tgz",
+            "integrity": "sha512-SCPsQmGVNY8h1rfS3aU0MzOGYY+wKIFukHEsoSIwPRCYocZkya7MFIlWIEYPWQZj+Gaksg6EyUaY255ZDqpQuA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@mswjs/interceptors": "^0.41.0",
                 "json-stringify-safe": "^5.0.1",
@@ -3894,7 +4002,8 @@
             "version": "2.0.36",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
             "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -4166,16 +4275,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/pathval": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-            "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4225,11 +4324,10 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-            "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -4360,7 +4458,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "license": "MIT",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4709,6 +4807,7 @@
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -4798,6 +4897,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -4919,18 +5019,17 @@
             }
         },
         "node_modules/test-exclude": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
-            "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
+            "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "@istanbuljs/schema": "^0.1.2",
-                "glob": "^10.4.1",
+                "glob": "^13.0.6",
                 "minimatch": "^10.2.2"
             },
             "engines": {
-                "node": ">=18"
+                "node": "20 || >=22"
             }
         },
         "node_modules/test-exclude/node_modules/balanced-match": {
@@ -4938,17 +5037,15 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "18 || 20 || >=22"
             }
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
@@ -4957,68 +5054,54 @@
             }
         },
         "node_modules/test-exclude/node_modules/glob": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/test-exclude/node_modules/glob/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/test-exclude/node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/test-exclude/node_modules/lru-cache": {
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+            "dev": true,
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/test-exclude/node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
-            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/test-exclude/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -5115,16 +5198,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/type-detect": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-            "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/typed-array-buffer": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -5204,11 +5277,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "license": "Apache-2.0",
-            "peer": true,
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -5237,10 +5308,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-            "license": "MIT"
+            "version": "7.19.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+            "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="
         },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",
@@ -5261,6 +5331,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.1"
@@ -5419,24 +5490,22 @@
             }
         },
         "node_modules/workerpool": {
-            "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-            "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
-            "dev": true,
-            "license": "Apache-2.0"
+            "version": "9.3.4",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+            "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+            "dev": true
         },
         "node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "license": "MIT",
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
             "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -5461,6 +5530,63 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/wrap-ansi/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
+        },
+        "node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5480,30 +5606,30 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "license": "MIT",
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+            "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
             "dependencies": {
-                "cliui": "^8.0.1",
+                "cliui": "^9.0.1",
                 "escalade": "^3.1.1",
                 "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
+                "string-width": "^7.2.0",
                 "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
+                "yargs-parser": "^22.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": "^20.19.0 || ^22.12.0 || >=23"
             }
         },
         "node_modules/yargs-parser": {
             "version": "21.1.1",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=12"
@@ -5523,6 +5649,60 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/yargs/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/yargs/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
+        },
+        "node_modules/yargs/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yargs/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/yargs/node_modules/yargs-parser": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
             }
         },
         "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -36,28 +36,28 @@
     "license": "Apache-2.0",
     "devDependencies": {
         "@duckduckgo/eslint-config": "github:duckduckgo/eslint-config#v0.1.0",
-        "@types/ajv": "^0.0.5",
+        "@types/ajv": "^1.0.4",
         "@types/mocha": "^10.0.10",
-        "c8": "^10.1.3",
-        "chai": "^4.5.0",
+        "c8": "^11.0.0",
+        "chai": "^6.2.2",
         "eslint": "^9.39.4",
         "eslint-plugin-import": "^2.32.0",
-        "mocha": "^11.3.0",
-        "nock": "^14.0.11",
-        "prettier": "^3.8.1"
+        "mocha": "^11.7.5",
+        "nock": "^14.0.13",
+        "prettier": "^3.8.3"
     },
     "dependencies": {
-        "@types/node": "^24.12.0",
+        "@types/node": "^25.6.0",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
-        "asana": "^3.1.9",
+        "asana": "^3.1.11",
         "compare-versions": "^6.1.1",
         "csv-parser": "^3.2.0",
         "js-yaml": "^4.1.1",
         "json-schema-traverse": "^1.0.0",
         "json5": "^2.2.3",
-        "typescript": "^5.9.3",
-        "yargs": "^17.7.2"
+        "typescript": "^6.0.3",
+        "yargs": "^18.0.0"
     },
     "prettier": {
         "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@duckduckgo/pixel-schema",
-    "version": "2.1.0",
+    "version": "2.1.2",
     "files": [
         "main.mjs",
         "bin",

--- a/schemas/wide_event_schema.json5
+++ b/schemas/wide_event_schema.json5
@@ -132,6 +132,32 @@
             },
             "additionalProperties": false
         },
+        "serviceSchemaProperty": {
+            "type": "object",
+            "description": "JSON Schema for the service section",
+            "required": ["type", "required", "additionalProperties", "properties"],
+            "properties": {
+                "type": { "const": "object" },
+                "required": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                },
+                "additionalProperties": { "const": false },
+                "properties": {
+                    "type": "object",
+                    "required": ["name", "version", "host", "region", "environment"],
+                    "properties": {
+                        "name": { "$ref": "#/$defs/stringValueProperty" },
+                        "version": { "$ref": "#/$defs/stringValueProperty" },
+                        "host": { "$ref": "#/$defs/stringValueProperty" },
+                        "region": { "$ref": "#/$defs/stringValueProperty" },
+                        "environment": { "$ref": "#/$defs/stringValueProperty" }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
         "dataSchemaProperty": {
             "type": "object",
             "description": "JSON Schema for the feature.data section",
@@ -351,9 +377,20 @@
                     "description": "Property schemas for validating wide event data",
                     "required": ["meta", "global", "feature"],
                     "additionalProperties": false,
+                    "oneOf": [
+                        {
+                            "required": ["app"],
+                            "not": { "required": ["service"] }
+                        },
+                        {
+                            "required": ["service"],
+                            "not": { "required": ["app"] }
+                        }
+                    ],
                     "properties": {
                         "meta": { "$ref": "#/$defs/metaSchemaProperty" },
                         "app": { "$ref": "#/$defs/appSchemaProperty" },
+                        "service": { "$ref": "#/$defs/serviceSchemaProperty" },
                         "global": { "$ref": "#/$defs/globalSchemaProperty" },
                         "feature": { "$ref": "#/$defs/featureSchemaProperty" },
                         "context": { "$ref": "#/$defs/contextSchemaProperty" },

--- a/schemas/wide_event_schema.json5
+++ b/schemas/wide_event_schema.json5
@@ -292,6 +292,28 @@
             },
             "additionalProperties": false
         },
+        "journeySchemaProperty": {
+            "type": "object",
+            "description": "JSON Schema for the journey section",
+            "required": ["type", "required", "additionalProperties", "properties"],
+            "properties": {
+                "type": { "const": "object" },
+                "required": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                },
+                "additionalProperties": { "const": false },
+                "properties": {
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                        "name": { "$ref": "#/$defs/stringEnumProperty" }
+		            },
+		            "additionalProperties": false
+		        }
+	        },
+	        "additionalProperties": false
+        },
 
         // The main wide event schema definition
         // This is a JSON Schema that validates wide event data
@@ -334,7 +356,8 @@
                         "app": { "$ref": "#/$defs/appSchemaProperty" },
                         "global": { "$ref": "#/$defs/globalSchemaProperty" },
                         "feature": { "$ref": "#/$defs/featureSchemaProperty" },
-                        "context": { "$ref": "#/$defs/contextSchemaProperty" }
+                        "context": { "$ref": "#/$defs/contextSchemaProperty" },
+                        "journey": { "$ref": "#/$defs/journeySchemaProperty" }
                     }
                 }
             }

--- a/schemas/wide_event_schema.json5
+++ b/schemas/wide_event_schema.json5
@@ -334,11 +334,11 @@
                     "required": ["name"],
                     "properties": {
                         "name": { "$ref": "#/$defs/stringEnumProperty" }
-		            },
-		            "additionalProperties": false
-		        }
-	        },
-	        "additionalProperties": false
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
         },
 
         // The main wide event schema definition

--- a/schemas/wide_event_schema.json5
+++ b/schemas/wide_event_schema.json5
@@ -125,7 +125,8 @@
                     "properties": {
                         "name": { "$ref": "#/$defs/stringEnumProperty" },
                         "version": { "$ref": "#/$defs/stringValueWithPatternProperty" },
-                        "form_factor": { "$ref": "#/$defs/form_factorDefinition" }
+                        "form_factor": { "$ref": "#/$defs/form_factorDefinition" },
+                        "dev_mode": { "$ref": "#/$defs/booleanProperty" }
                     },
                     "additionalProperties": false
                 }
@@ -249,6 +250,7 @@
                     "properties": {
                         "name": { "$ref": "#/$defs/stringEnumProperty" },
                         "status": { "$ref": "#/$defs/statusDefinition" },
+                        "status_reason": { "$ref": "#/$defs/stringEnumProperty" },
                         "data": { "$ref": "#/$defs/dataSchemaProperty" }
                     },
                     "additionalProperties": false

--- a/src/definitions_validator.mjs
+++ b/src/definitions_validator.mjs
@@ -280,6 +280,7 @@ export class WideEventDefinitionsValidator extends BaseDefinitionsValidator {
         // Determine required top-level properties
         const requiredProps = ['meta', 'global', 'feature'];
         if (baseEvent.app) requiredProps.push('app');
+        if (baseEvent.service) requiredProps.push('service');
         if (eventDef.context) requiredProps.push('context');
 
         // Build properties object
@@ -301,6 +302,11 @@ export class WideEventDefinitionsValidator extends BaseDefinitionsValidator {
             const appProps = JSON.parse(JSON.stringify(baseEvent.app));
             const appRequired = getSectionRequiredKeysFromMetaSchema('app');
             properties.app = this.#wrapSectionAsJsonSchema(appProps, appRequired);
+        }
+        if (baseEvent.service) {
+            const serviceProps = JSON.parse(JSON.stringify(baseEvent.service));
+            const serviceRequired = getSectionRequiredKeysFromMetaSchema('service');
+            properties.service = this.#wrapSectionAsJsonSchema(serviceProps, serviceRequired);
         }
 
         // global section from base_event
@@ -449,6 +455,10 @@ export class WideEventDefinitionsValidator extends BaseDefinitionsValidator {
             }
             if (eventDef.app) {
                 const error = `${eventName}: 'app' section should not be defined in event - it comes from base_event.json`;
+                errors.push(error);
+            }
+            if (eventDef.service) {
+                const error = `${eventName}: 'service' section should not be defined in event - it comes from base_event.json`;
                 errors.push(error);
             }
             if (eventDef.global) {

--- a/src/definitions_validator.mjs
+++ b/src/definitions_validator.mjs
@@ -356,11 +356,17 @@ export class WideEventDefinitionsValidator extends BaseDefinitionsValidator {
         properties.feature = this.#wrapSectionAsJsonSchema(featureProperties, featureRequired);
 
         // Optional sections sourced from event definition (e.g. context/journey)
-        // Deep clone from base_event and set name.enum from the event's array value.
+        // Deep clone base, then overlay each event-defined property (arrays become enums).
         for (const sectionName of WIDE_EVENT_EVENT_SECTIONS) {
             if (!eventDef[sectionName]) continue;
             const sectionProps = JSON.parse(JSON.stringify(baseEvent[sectionName] ?? {}));
-            sectionProps.name = { ...sectionProps.name, enum: eventDef[sectionName] };
+            for (const [key, value] of Object.entries(eventDef[sectionName])) {
+                if (Array.isArray(value)) {
+                    sectionProps[key] = { ...sectionProps[key], enum: value };
+                } else {
+                    sectionProps[key] = JSON.parse(JSON.stringify(value));
+                }
+            }
             const sectionRequired = getSectionRequiredKeysFromMetaSchema(sectionName);
             properties[sectionName] = this.#wrapSectionAsJsonSchema(sectionProps, sectionRequired);
         }

--- a/src/definitions_validator.mjs
+++ b/src/definitions_validator.mjs
@@ -21,15 +21,8 @@ const nativeExperimentsSchema = JSON5.parse(fs.readFileSync(path.join(schemasPat
 const searchExperimentsSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'search_experiments_schema.json5')).toString());
 const wideEventSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'wide_event_schema.json5')).toString());
 
-const WIDE_EVENT_SECTION_SCHEMA_DEF_MAP = {
-    app: 'appSchemaProperty',
-    global: 'globalSchemaProperty',
-    feature: 'featureSchemaProperty',
-    context: 'contextSchemaProperty',
-};
-
 function getSectionRequiredKeysFromMetaSchema(sectionName) {
-    const schemaDefName = WIDE_EVENT_SECTION_SCHEMA_DEF_MAP[sectionName];
+    const schemaDefName = `${sectionName}SchemaProperty`;
     const sectionDef = wideEventSchema?.$defs?.[schemaDefName];
     const required = sectionDef?.properties?.properties?.required;
     return Array.isArray(required) ? [...required] : [];

--- a/src/definitions_validator.mjs
+++ b/src/definitions_validator.mjs
@@ -318,7 +318,6 @@ export class WideEventDefinitionsValidator extends BaseDefinitionsValidator {
 
         // feature section — deep clone base, then overlay event-specific values
         const featureProperties = JSON.parse(JSON.stringify(baseEvent.feature ?? {}));
-        delete featureProperties.data;
         featureProperties.name = { ...featureProperties.name, enum: [eventDef.feature?.name] };
         featureProperties.status = { ...featureProperties.status, enum: eventDef.feature?.status };
 

--- a/src/definitions_validator.mjs
+++ b/src/definitions_validator.mjs
@@ -20,8 +20,9 @@ const suffixSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'suffix_
 const nativeExperimentsSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'native_experiments_schema.json5')).toString());
 const searchExperimentsSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'search_experiments_schema.json5')).toString());
 const wideEventSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'wide_event_schema.json5')).toString());
-const WIDE_EVENT_OPTIONAL_BASE_SECTIONS = ['app', 'service'];
-const WIDE_EVENT_DISALLOWED_EVENT_SECTIONS = ['app', 'service', 'global'];
+const WIDE_EVENT_BASE_SECTIONS = ['app', 'service'];
+const WIDE_EVENT_EVENT_SECTIONS = ['context', 'journey'];
+const WIDE_EVENT_DISALLOWED_EVENT_SECTIONS = [...WIDE_EVENT_BASE_SECTIONS, 'global'];
 
 function getSectionRequiredKeysFromMetaSchema(sectionName) {
     const schemaDefName = `${sectionName}SchemaProperty`;
@@ -281,10 +282,12 @@ export class WideEventDefinitionsValidator extends BaseDefinitionsValidator {
 
         // Determine required top-level properties
         const requiredProps = ['meta', 'global', 'feature'];
-        for (const sectionName of WIDE_EVENT_OPTIONAL_BASE_SECTIONS) {
+        for (const sectionName of WIDE_EVENT_BASE_SECTIONS) {
             if (baseEvent[sectionName]) requiredProps.push(sectionName);
         }
-        if (eventDef.context) requiredProps.push('context');
+        for (const sectionName of WIDE_EVENT_EVENT_SECTIONS) {
+            if (eventDef[sectionName]) requiredProps.push(sectionName);
+        }
 
         // Build properties object
         const properties = {};
@@ -301,7 +304,7 @@ export class WideEventDefinitionsValidator extends BaseDefinitionsValidator {
         };
 
         // Optional sections sourced from base_event (e.g. app/service)
-        for (const sectionName of WIDE_EVENT_OPTIONAL_BASE_SECTIONS) {
+        for (const sectionName of WIDE_EVENT_BASE_SECTIONS) {
             if (!baseEvent[sectionName]) continue;
             const sectionProps = JSON.parse(JSON.stringify(baseEvent[sectionName]));
             const sectionRequired = getSectionRequiredKeysFromMetaSchema(sectionName);
@@ -313,102 +316,53 @@ export class WideEventDefinitionsValidator extends BaseDefinitionsValidator {
         const globalRequired = getSectionRequiredKeysFromMetaSchema('global');
         properties.global = this.#wrapSectionAsJsonSchema(globalProps, globalRequired);
 
-        // feature section - merge base structure with event-specific values
-        const featureNameDef = {
-            ...baseEvent.feature?.name,
-            enum: [eventDef.feature?.name],
-        };
-        const featureStatusDef = {
-            ...baseEvent.feature?.status,
-            enum: eventDef.feature?.status,
-        };
-        const featureRequired = getSectionRequiredKeysFromMetaSchema('feature');
-        const featureProperties = {
-            name: featureNameDef,
-            status: featureStatusDef,
-        };
+        // feature section — deep clone base, then overlay event-specific values
+        const featureProperties = JSON.parse(JSON.stringify(baseEvent.feature ?? {}));
+        delete featureProperties.data;
+        featureProperties.name = { ...featureProperties.name, enum: [eventDef.feature?.name] };
+        featureProperties.status = { ...featureProperties.status, enum: eventDef.feature?.status };
 
-        // Include base_event feature props beyond name/status/data (optional unless in metaschema required set)
-        const baseFeature = baseEvent.feature ?? {};
-        for (const [key, value] of Object.entries(baseFeature)) {
-            if (key === 'name' || key === 'status' || key === 'data') continue;
-            featureProperties[key] = JSON.parse(JSON.stringify(value));
-        }
-
-        // Expand shortcuts in feature.data.ext
-        const eventData = eventDef.feature?.data || { ext: {} };
-        const expandedExt = this.#expandPropertiesShortcuts(eventData.ext || {});
-
-        const extProperties = {
-            type: 'object',
-            additionalProperties: false,
-            properties: expandedExt,
-        };
-
-        const dataProperties = { ext: extProperties };
-        const dataRequired = ['ext'];
-
-        // Include error if present in event data
-        if (eventData.error) {
-            dataProperties.error = {
-                type: 'object',
-                required: ['domain', 'code'],
-                additionalProperties: false,
-                properties: eventData.error,
-            };
-        }
-
-        // Include any other properties defined directly under feature.data
-        for (const [key, value] of Object.entries(eventData)) {
-            if (key === 'ext' || key === 'error') continue;
-            dataProperties[key] = value;
-        }
-
-        const featureDataDef = {
-            type: 'object',
-            required: dataRequired,
-            additionalProperties: false,
-            properties: dataProperties,
-        };
-
-        // Include event-defined feature props beyond name/status/data
+        // Merge additional event-defined feature properties (event overrides base)
         const eventFeature = eventDef.feature ?? {};
         for (const [key, value] of Object.entries(eventFeature)) {
             if (key === 'name' || key === 'status' || key === 'data') continue;
             featureProperties[key] = JSON.parse(JSON.stringify(value));
         }
 
-        properties.feature = {
+        // Build feature.data — deep clone then transform ext and error in place
+        const eventData = eventDef.feature?.data || { ext: {} };
+        const dataProperties = JSON.parse(JSON.stringify(eventData));
+        dataProperties.ext = {
             type: 'object',
-            required: featureRequired,
             additionalProperties: false,
-            properties: {
-                ...featureProperties,
-                data: featureDataDef,
-            },
+            properties: this.#expandPropertiesShortcuts(eventData.ext || {}),
         };
-
-        // context section (optional) - transform array to enum
-        if (eventDef.context) {
-            const contextNameDef = {
-                ...baseEvent.context?.name,
-                enum: eventDef.context,
-            };
-            const contextRequired = getSectionRequiredKeysFromMetaSchema('context');
-            const contextProperties = {
-                name: contextNameDef,
-            };
-            const baseContext = baseEvent.context ?? {};
-            for (const [key, value] of Object.entries(baseContext)) {
-                if (key === 'name') continue;
-                contextProperties[key] = JSON.parse(JSON.stringify(value));
-            }
-            properties.context = {
+        if (dataProperties.error) {
+            dataProperties.error = {
                 type: 'object',
-                required: contextRequired,
+                required: ['domain', 'code'],
                 additionalProperties: false,
-                properties: contextProperties,
+                properties: dataProperties.error,
             };
+        }
+
+        const featureRequired = getSectionRequiredKeysFromMetaSchema('feature');
+        featureProperties.data = {
+            type: 'object',
+            required: ['ext'],
+            additionalProperties: false,
+            properties: dataProperties,
+        };
+        properties.feature = this.#wrapSectionAsJsonSchema(featureProperties, featureRequired);
+
+        // Optional sections sourced from event definition (e.g. context/journey)
+        // Deep clone from base_event and set name.enum from the event's array value.
+        for (const sectionName of WIDE_EVENT_EVENT_SECTIONS) {
+            if (!eventDef[sectionName]) continue;
+            const sectionProps = JSON.parse(JSON.stringify(baseEvent[sectionName] ?? {}));
+            sectionProps.name = { ...sectionProps.name, enum: eventDef[sectionName] };
+            const sectionRequired = getSectionRequiredKeysFromMetaSchema(sectionName);
+            properties[sectionName] = this.#wrapSectionAsJsonSchema(sectionProps, sectionRequired);
         }
 
         // Build the complete JSON Schema

--- a/src/definitions_validator.mjs
+++ b/src/definitions_validator.mjs
@@ -20,6 +20,8 @@ const suffixSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'suffix_
 const nativeExperimentsSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'native_experiments_schema.json5')).toString());
 const searchExperimentsSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'search_experiments_schema.json5')).toString());
 const wideEventSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'wide_event_schema.json5')).toString());
+const WIDE_EVENT_OPTIONAL_BASE_SECTIONS = ['app', 'service'];
+const WIDE_EVENT_DISALLOWED_EVENT_SECTIONS = ['app', 'service', 'global'];
 
 function getSectionRequiredKeysFromMetaSchema(sectionName) {
     const schemaDefName = `${sectionName}SchemaProperty`;
@@ -279,8 +281,9 @@ export class WideEventDefinitionsValidator extends BaseDefinitionsValidator {
 
         // Determine required top-level properties
         const requiredProps = ['meta', 'global', 'feature'];
-        if (baseEvent.app) requiredProps.push('app');
-        if (baseEvent.service) requiredProps.push('service');
+        for (const sectionName of WIDE_EVENT_OPTIONAL_BASE_SECTIONS) {
+            if (baseEvent[sectionName]) requiredProps.push(sectionName);
+        }
         if (eventDef.context) requiredProps.push('context');
 
         // Build properties object
@@ -297,16 +300,12 @@ export class WideEventDefinitionsValidator extends BaseDefinitionsValidator {
             },
         };
 
-        // app section from base_event (if present)
-        if (baseEvent.app) {
-            const appProps = JSON.parse(JSON.stringify(baseEvent.app));
-            const appRequired = getSectionRequiredKeysFromMetaSchema('app');
-            properties.app = this.#wrapSectionAsJsonSchema(appProps, appRequired);
-        }
-        if (baseEvent.service) {
-            const serviceProps = JSON.parse(JSON.stringify(baseEvent.service));
-            const serviceRequired = getSectionRequiredKeysFromMetaSchema('service');
-            properties.service = this.#wrapSectionAsJsonSchema(serviceProps, serviceRequired);
+        // Optional sections sourced from base_event (e.g. app/service)
+        for (const sectionName of WIDE_EVENT_OPTIONAL_BASE_SECTIONS) {
+            if (!baseEvent[sectionName]) continue;
+            const sectionProps = JSON.parse(JSON.stringify(baseEvent[sectionName]));
+            const sectionRequired = getSectionRequiredKeysFromMetaSchema(sectionName);
+            properties[sectionName] = this.#wrapSectionAsJsonSchema(sectionProps, sectionRequired);
         }
 
         // global section from base_event
@@ -453,16 +452,9 @@ export class WideEventDefinitionsValidator extends BaseDefinitionsValidator {
             if (eventDef.meta.type !== eventName) {
                 throw new Error(`${eventName}: 'meta.type' must match event key`);
             }
-            if (eventDef.app) {
-                const error = `${eventName}: 'app' section should not be defined in event - it comes from base_event.json`;
-                errors.push(error);
-            }
-            if (eventDef.service) {
-                const error = `${eventName}: 'service' section should not be defined in event - it comes from base_event.json`;
-                errors.push(error);
-            }
-            if (eventDef.global) {
-                const error = `${eventName}: 'global' section should not be defined in event - it comes from base_event.json`;
+            for (const sectionName of WIDE_EVENT_DISALLOWED_EVENT_SECTIONS) {
+                if (!eventDef[sectionName]) continue;
+                const error = `${eventName}: '${sectionName}' section should not be defined in event - it comes from base_event.json`;
                 errors.push(error);
             }
 

--- a/tests/pixel_definition_validation_test.mjs
+++ b/tests/pixel_definition_validation_test.mjs
@@ -1,9 +1,4 @@
 import { expect } from 'chai';
-import Ajv2020 from 'ajv/dist/2020.js';
-import fs from 'fs';
-import JSON5 from 'json5';
-import path from 'path';
-import { fileURLToPath } from 'url';
 
 import { PixelDefinitionsValidator, WideEventDefinitionsValidator } from '../src/definitions_validator.mjs';
 import { ParamsValidator } from '../src/params_validator.mjs';
@@ -1330,80 +1325,95 @@ describe('Wide Event required fields follow metaschema', () => {
     });
 });
 
-describe('Wide Event metaschema section definitions', () => {
-    const schemasPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'schemas');
-    const wideEventSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'wide_event_schema.json5')).toString());
-    const propSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'prop_schema.json5')).toString());
+describe('Wide Event app/service section handling', () => {
+    const makeValidator = () => new WideEventDefinitionsValidator({});
+    const event = {
+        w_app_or_service: {
+            description: 'Validates app xor service section generation',
+            owners: ['tester'],
+            meta: { type: 'w_app_or_service', version: '0.0' },
+            feature: {
+                name: 'feature',
+                status: ['SUCCESS'],
+                data: { ext: {} },
+            },
+        },
+    };
 
-    // eslint-disable-next-line new-cap
-    const ajv = new Ajv2020.default({ allErrors: true });
-    ajv.addSchema(propSchema);
+    const baseCommon = {
+        meta: {
+            version: {
+                description: 'Base event version',
+                value: 1,
+            },
+        },
+        global: {
+            platform: { type: 'string', description: 'Platform', enum: ['Linux'] },
+            type: { type: 'string', description: 'Type', enum: ['service', 'app'] },
+            sample_rate: { type: 'number', description: 'Sample rate', minimum: 0, maximum: 1 },
+        },
+        feature: {
+            name: { type: 'string', description: 'Feature name' },
+            status: { type: 'string', description: 'Status' },
+            data: { ext: {} },
+        },
+    };
 
-    const contextSchemaValidator = ajv.compile({
-        $ref: '#/$defs/contextSchemaProperty',
-        $defs: wideEventSchema.$defs,
-    });
-
-    const journeySchemaValidator = ajv.compile({
-        $ref: '#/$defs/journeySchemaProperty',
-        $defs: wideEventSchema.$defs,
-    });
-
-    it('accepts a valid contextSchemaProperty section', () => {
-        const validContextSection = {
-            type: 'object',
-            required: ['name'],
-            additionalProperties: false,
-            properties: {
-                name: {
-                    type: 'string',
-                    description: 'Context name',
-                    enum: ['onboarding', 'settings'],
-                },
+    it('supports app section from base_event', () => {
+        const baseEvent = {
+            ...baseCommon,
+            app: {
+                name: { type: 'string', description: 'App name', enum: ['Windows'] },
+                version: { type: 'string', description: 'App version', pattern: '^[0-9]+\\.[0-9]+\\.[0-9]+$' },
             },
         };
-
-        expect(contextSchemaValidator(validContextSection)).to.be.true;
+        const { errors, generatedSchemas } = makeValidator().validateWideEventDefinition(event, baseEvent);
+        expect(errors).to.be.empty;
+        const generated = generatedSchemas.w_app_or_service;
+        expect(generated.properties).to.have.property('app');
+        expect(generated.properties).to.not.have.property('service');
     });
 
-    it('rejects an invalid contextSchemaProperty section', () => {
-        const invalidContextSection = {
-            type: 'object',
-            required: ['name'],
-            additionalProperties: false,
-            properties: {},
-        };
-
-        expect(contextSchemaValidator(invalidContextSection)).to.be.false;
-        expect(contextSchemaValidator.errors?.some((error) => error.message?.includes("must have required property 'name'"))).to.be.true;
-    });
-
-    it('accepts a valid journeySchemaProperty section', () => {
-        const validJourneySection = {
-            type: 'object',
-            required: ['name'],
-            additionalProperties: false,
-            properties: {
-                name: {
-                    type: 'string',
-                    description: 'Journey name',
-                    enum: ['first_run', 'returning_user'],
-                },
+    it('supports service section from base_event', () => {
+        const baseEvent = {
+            ...baseCommon,
+            service: {
+                name: { type: 'string', description: 'Service name' },
+                version: { type: 'string', description: 'Service version' },
+                host: { type: 'string', description: 'Host name' },
+                region: { type: 'string', description: 'Region name' },
+                environment: { type: 'string', description: 'Environment name' },
             },
         };
-
-        expect(journeySchemaValidator(validJourneySection)).to.be.true;
+        const { errors, generatedSchemas } = makeValidator().validateWideEventDefinition(event, baseEvent);
+        expect(errors).to.be.empty;
+        const generated = generatedSchemas.w_app_or_service;
+        expect(generated.properties).to.have.property('service');
+        expect(generated.properties).to.not.have.property('app');
+        expect(generated.properties.service.required).to.deep.equal(['name', 'version', 'host', 'region', 'environment']);
     });
 
-    it('rejects an invalid journeySchemaProperty section', () => {
-        const invalidJourneySection = {
-            type: 'object',
-            required: ['name'],
-            additionalProperties: false,
-            properties: {},
+    it('rejects schema generation when both app and service are present in base_event', () => {
+        const baseEvent = {
+            ...baseCommon,
+            app: {
+                name: { type: 'string', description: 'App name', enum: ['Windows'] },
+                version: { type: 'string', description: 'App version', pattern: '^[0-9]+\\.[0-9]+\\.[0-9]+$' },
+            },
+            service: {
+                name: { type: 'string', description: 'Service name' },
+                version: { type: 'string', description: 'Service version' },
+                host: { type: 'string', description: 'Host name' },
+                region: { type: 'string', description: 'Region name' },
+                environment: { type: 'string', description: 'Environment name' },
+            },
         };
+        const { errors } = makeValidator().validateWideEventDefinition(event, baseEvent);
+        expect(errors.some((error) => error.includes('Generated schema does not match metaschema'))).to.be.true;
+    });
 
-        expect(journeySchemaValidator(invalidJourneySection)).to.be.false;
-        expect(journeySchemaValidator.errors?.some((error) => error.message?.includes("must have required property 'name'"))).to.be.true;
+    it('rejects schema generation when neither app nor service are present in base_event', () => {
+        const { errors } = makeValidator().validateWideEventDefinition(event, baseCommon);
+        expect(errors.some((error) => error.includes('Generated schema does not match metaschema'))).to.be.true;
     });
 });

--- a/tests/pixel_definition_validation_test.mjs
+++ b/tests/pixel_definition_validation_test.mjs
@@ -630,7 +630,7 @@ describe('Wide Event Validation', () => {
                 type: 'w_test_event',
                 version: '0.0',
             },
-            context: ['test-context'],
+            context: { name: ['test-context'] },
             feature: {
                 name: 'test-feature',
                 status: ['SUCCESS'],
@@ -772,7 +772,7 @@ describe('Wide Event Validation', () => {
                 description: 'Event missing feature',
                 owners: ['tester'],
                 meta: { type: 'w_no_feature', version: '0.0' },
-                context: ['test'],
+                context: { name: ['test'] },
                 // feature is missing - schema validation catches malformed merged result
             },
         };
@@ -864,7 +864,7 @@ describe('Wide Event Base Event Merging', () => {
                 type: 'w_test_merge',
                 version: '0.0',
             },
-            context: ['onboarding', 'settings'],
+            context: { name: ['onboarding', 'settings'] },
             feature: {
                 name: 'test-feature',
                 status: ['SUCCESS', 'FAILURE'],
@@ -911,7 +911,7 @@ describe('Wide Event Base Event Merging', () => {
                     type: 'w_test_shortcut_merge',
                     version: '0.0',
                 },
-                context: ['settings'],
+                context: { name: ['settings'] },
                 feature: {
                     name: 'shortcut-test',
                     status: ['SUCCESS'],
@@ -942,7 +942,7 @@ describe('Wide Event Base Event Merging', () => {
                 description: 'First event',
                 owners: ['tester'],
                 meta: { type: 'w_event_one', version: '0.0' },
-                context: ['ctx1'],
+                context: { name: ['ctx1'] },
                 feature: {
                     name: 'feature-one',
                     status: ['SUCCESS'],
@@ -953,7 +953,7 @@ describe('Wide Event Base Event Merging', () => {
                 description: 'Second event',
                 owners: ['tester'],
                 meta: { type: 'w_event_two', version: '0.0' },
-                context: ['ctx2'],
+                context: { name: ['ctx2'] },
                 feature: {
                     name: 'feature-two',
                     status: ['FAILURE'],
@@ -1090,7 +1090,7 @@ describe('Wide Event Base Event Merging', () => {
                 description: 'Event with custom feature/data props',
                 owners: ['tester'],
                 meta: { type: 'w_no_drops', version: '0.0' },
-                context: ['alpha'],
+                context: { name: ['alpha'] },
                 feature: {
                     name: 'no-drops',
                     status: ['SUCCESS'],
@@ -1186,7 +1186,7 @@ describe('Wide Event Version Combining', () => {
                 description: 'Version test event',
                 owners: ['tester'],
                 meta: { type: 'w_version_test', version: '3.5' },
-                context: ['test'],
+                context: { name: ['test'] },
                 feature: {
                     name: 'version-feature',
                     status: ['SUCCESS'],
@@ -1209,7 +1209,7 @@ describe('Wide Event Version Combining', () => {
                 description: 'Zero version event',
                 owners: ['tester'],
                 meta: { type: 'w_zero_version', version: '0.0' },
-                context: ['test'],
+                context: { name: ['test'] },
                 feature: {
                     name: 'zero-feature',
                     status: ['SUCCESS'],
@@ -1232,7 +1232,7 @@ describe('Wide Event Version Combining', () => {
                 description: 'Test that base meta is not included',
                 owners: ['tester'],
                 meta: { type: 'w_no_base_meta', version: '1.0' },
-                context: ['test'],
+                context: { name: ['test'] },
                 feature: {
                     name: 'test-feature',
                     status: ['SUCCESS'],
@@ -1287,7 +1287,7 @@ describe('Wide Event required fields follow metaschema', () => {
         description: 'Event with optional base fields',
         owners: ['tester'],
         meta: { type: 'w_optional_base_fields', version: '0.0' },
-        context: ['onboarding'],
+        context: { name: ['onboarding'] },
         feature: {
             name: 'optional-base-fields-feature',
             status: ['SUCCESS'],
@@ -1452,7 +1452,7 @@ describe('Wide Event journey section handling', () => {
                 description: 'Event with journey',
                 owners: ['tester'],
                 meta: { type: 'w_with_journey', version: '0.0' },
-                journey: ['first_run', 'returning_user'],
+                journey: { name: ['first_run', 'returning_user'] },
                 feature: {
                     name: 'with-journey',
                     status: ['SUCCESS'],
@@ -1501,8 +1501,8 @@ describe('Wide Event journey section handling', () => {
                 description: 'Event with both journey and context',
                 owners: ['tester'],
                 meta: { type: 'w_journey_and_context', version: '0.0' },
-                context: ['settings'],
-                journey: ['onboarding'],
+                context: { name: ['settings'] },
+                journey: { name: ['onboarding'] },
                 feature: {
                     name: 'journey-and-context',
                     status: ['SUCCESS'],

--- a/tests/pixel_definition_validation_test.mjs
+++ b/tests/pixel_definition_validation_test.mjs
@@ -1417,3 +1417,105 @@ describe('Wide Event app/service section handling', () => {
         expect(errors.some((error) => error.includes('Generated schema does not match metaschema'))).to.be.true;
     });
 });
+
+describe('Wide Event journey section handling', () => {
+    const makeValidator = () => new WideEventDefinitionsValidator({});
+    const baseEvent = {
+        meta: {
+            version: {
+                description: 'Base event version',
+                value: 1,
+            },
+        },
+        app: {
+            name: { type: 'string', description: 'App name', enum: ['Windows'] },
+            version: { type: 'string', description: 'App version', pattern: '^[0-9]+\\.[0-9]+\\.[0-9]+$' },
+        },
+        global: {
+            platform: { type: 'string', description: 'Platform', enum: ['Windows'] },
+            type: { type: 'string', description: 'Type', enum: ['app'] },
+            sample_rate: { type: 'number', description: 'Sample rate', minimum: 0, maximum: 1 },
+        },
+        feature: {
+            name: { type: 'string', description: 'Feature name' },
+            status: { type: 'string', description: 'Status' },
+            data: { ext: {} },
+        },
+        journey: {
+            name: { type: 'string', description: 'Journey name' },
+        },
+    };
+
+    it('includes journey section when event definition provides it', () => {
+        const event = {
+            w_with_journey: {
+                description: 'Event with journey',
+                owners: ['tester'],
+                meta: { type: 'w_with_journey', version: '0.0' },
+                journey: ['first_run', 'returning_user'],
+                feature: {
+                    name: 'with-journey',
+                    status: ['SUCCESS'],
+                    data: { ext: {} },
+                },
+            },
+        };
+        const { errors, generatedSchemas } = makeValidator().validateWideEventDefinition(event, baseEvent);
+        expect(errors).to.be.empty;
+        const generated = generatedSchemas.w_with_journey;
+        expect(generated.properties).to.have.property('journey');
+        expect(generated.required).to.include('journey');
+        expect(generated.properties.journey.required).to.deep.equal(['name']);
+        expect(generated.properties.journey.properties.name.enum).to.deep.equal(['first_run', 'returning_user']);
+    });
+
+    it('omits journey section when event definition does not provide it', () => {
+        const event = {
+            w_without_journey: {
+                description: 'Event without journey',
+                owners: ['tester'],
+                meta: { type: 'w_without_journey', version: '0.0' },
+                feature: {
+                    name: 'without-journey',
+                    status: ['SUCCESS'],
+                    data: { ext: {} },
+                },
+            },
+        };
+        const { errors, generatedSchemas } = makeValidator().validateWideEventDefinition(event, baseEvent);
+        expect(errors).to.be.empty;
+        const generated = generatedSchemas.w_without_journey;
+        expect(generated.properties).to.not.have.property('journey');
+        expect(generated.required).to.not.include('journey');
+    });
+
+    it('works alongside context when both are present', () => {
+        const baseWithContext = {
+            ...baseEvent,
+            context: {
+                name: { type: 'string', description: 'Context name' },
+            },
+        };
+        const event = {
+            w_journey_and_context: {
+                description: 'Event with both journey and context',
+                owners: ['tester'],
+                meta: { type: 'w_journey_and_context', version: '0.0' },
+                context: ['settings'],
+                journey: ['onboarding'],
+                feature: {
+                    name: 'journey-and-context',
+                    status: ['SUCCESS'],
+                    data: { ext: {} },
+                },
+            },
+        };
+        const { errors, generatedSchemas } = makeValidator().validateWideEventDefinition(event, baseWithContext);
+        expect(errors).to.be.empty;
+        const generated = generatedSchemas.w_journey_and_context;
+        expect(generated.properties).to.have.property('context');
+        expect(generated.properties).to.have.property('journey');
+        expect(generated.properties.journey.properties.name.enum).to.deep.equal(['onboarding']);
+        expect(generated.properties.context.properties.name.enum).to.deep.equal(['settings']);
+    });
+});

--- a/tests/pixel_definition_validation_test.mjs
+++ b/tests/pixel_definition_validation_test.mjs
@@ -1,4 +1,9 @@
 import { expect } from 'chai';
+import Ajv2020 from 'ajv/dist/2020.js';
+import fs from 'fs';
+import JSON5 from 'json5';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 import { PixelDefinitionsValidator, WideEventDefinitionsValidator } from '../src/definitions_validator.mjs';
 import { ParamsValidator } from '../src/params_validator.mjs';
@@ -1322,5 +1327,83 @@ describe('Wide Event required fields follow metaschema', () => {
         expect(generated.properties.global.required).to.deep.equal(['platform', 'type', 'sample_rate']);
         expect(generated.properties.feature.required).to.deep.equal(['name', 'status', 'data']);
         expect(generated.properties.context.required).to.deep.equal(['name']);
+    });
+});
+
+describe('Wide Event metaschema section definitions', () => {
+    const schemasPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'schemas');
+    const wideEventSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'wide_event_schema.json5')).toString());
+    const propSchema = JSON5.parse(fs.readFileSync(path.join(schemasPath, 'prop_schema.json5')).toString());
+
+    // eslint-disable-next-line new-cap
+    const ajv = new Ajv2020.default({ allErrors: true });
+    ajv.addSchema(propSchema);
+
+    const contextSchemaValidator = ajv.compile({
+        $ref: '#/$defs/contextSchemaProperty',
+        $defs: wideEventSchema.$defs,
+    });
+
+    const journeySchemaValidator = ajv.compile({
+        $ref: '#/$defs/journeySchemaProperty',
+        $defs: wideEventSchema.$defs,
+    });
+
+    it('accepts a valid contextSchemaProperty section', () => {
+        const validContextSection = {
+            type: 'object',
+            required: ['name'],
+            additionalProperties: false,
+            properties: {
+                name: {
+                    type: 'string',
+                    description: 'Context name',
+                    enum: ['onboarding', 'settings'],
+                },
+            },
+        };
+
+        expect(contextSchemaValidator(validContextSection)).to.be.true;
+    });
+
+    it('rejects an invalid contextSchemaProperty section', () => {
+        const invalidContextSection = {
+            type: 'object',
+            required: ['name'],
+            additionalProperties: false,
+            properties: {},
+        };
+
+        expect(contextSchemaValidator(invalidContextSection)).to.be.false;
+        expect(contextSchemaValidator.errors?.some((error) => error.message?.includes("must have required property 'name'"))).to.be.true;
+    });
+
+    it('accepts a valid journeySchemaProperty section', () => {
+        const validJourneySection = {
+            type: 'object',
+            required: ['name'],
+            additionalProperties: false,
+            properties: {
+                name: {
+                    type: 'string',
+                    description: 'Journey name',
+                    enum: ['first_run', 'returning_user'],
+                },
+            },
+        };
+
+        expect(journeySchemaValidator(validJourneySection)).to.be.true;
+    });
+
+    it('rejects an invalid journeySchemaProperty section', () => {
+        const invalidJourneySection = {
+            type: 'object',
+            required: ['name'],
+            additionalProperties: false,
+            properties: {},
+        };
+
+        expect(journeySchemaValidator(invalidJourneySection)).to.be.false;
+        expect(journeySchemaValidator.errors?.some((error) => error.message?.includes("must have required property 'name'"))).to.be.true;
     });
 });

--- a/tests/test_data/invalid/wide_events/definitions/wide_events.json
+++ b/tests/test_data/invalid/wide_events/definitions/wide_events.json
@@ -6,7 +6,7 @@
             "type": "w_wide_import_summary",
             "version": "0.0"
         },
-        "context": ["onboarding", "settings"],
+        "context": { "name": ["onboarding", "settings"] },
         "feature": {
             "name": "browser-import",
             "data": {
@@ -124,7 +124,7 @@
             "type": "w_wide_import_credentials",
             "version": "0.0"
         },
-        "context": ["onboarding.import", "settings.import"],
+        "context": { "name": ["onboarding.import", "settings.import"] },
         "feature": {
             "data": {
                 "latency_ms_bucketed": {
@@ -175,7 +175,7 @@
             "type": "w_wide_import_timeout",
             "version": "0.0"
         },
-        "context": ["onboarding", "settings"],
+        "context": { "name": ["onboarding", "settings"] },
         "feature": {
             "name": "browser-import",
             "status": ["FAILURE"],
@@ -220,7 +220,7 @@
             "type": "w_wide_import_cancelled",
             "version": "0.0"
         },
-        "context": ["onboarding", "settings"],
+        "context": { "name": ["onboarding", "settings"] },
         "feature": {
             "name": "browser-import",
             "status": ["CANCELLED"],

--- a/tests/test_data/invalid/wide_events/generated_schemas/w_wide_import_bookmarks-1.0.0.json
+++ b/tests/test_data/invalid/wide_events/generated_schemas/w_wide_import_bookmarks-1.0.0.json
@@ -42,6 +42,11 @@
                     "required": ["ext"],
                     "additionalProperties": false,
                     "properties": {
+                        "latency_ms_bucketed": {
+                            "type": "integer",
+                            "description": "How long the bookmark import took in milliseconds, bucketed to preserve privacy",
+                            "enum": [1, 5, 10, 20, 50, 100, 500, 1000, 5000, 10000]
+                        },
                         "ext": {
                             "type": "object",
                             "additionalProperties": false,
@@ -70,11 +75,6 @@
                                     "enum": [1, 5, 10, 20, 50, 100, 500, 1000]
                                 }
                             }
-                        },
-                        "latency_ms_bucketed": {
-                            "type": "integer",
-                            "description": "How long the bookmark import took in milliseconds, bucketed to preserve privacy",
-                            "enum": [1, 5, 10, 20, 50, 100, 500, 1000, 5000, 10000]
                         },
                         "failure_detail": {
                             "type": "string",

--- a/tests/test_data/invalid/wide_events/generated_schemas/w_wide_import_credentials-1.0.0.json
+++ b/tests/test_data/invalid/wide_events/generated_schemas/w_wide_import_credentials-1.0.0.json
@@ -42,6 +42,11 @@
                     "required": ["ext"],
                     "additionalProperties": false,
                     "properties": {
+                        "latency_ms_bucketed": {
+                            "type": "integer",
+                            "description": "How long the credential import took in milliseconds, bucketed to preserve privacy",
+                            "enum": [1, 5, 10, 20, 50, 100, 500, 1000, 5000, 10000]
+                        },
                         "ext": {
                             "type": "object",
                             "additionalProperties": false,
@@ -73,11 +78,6 @@
                                     "enum": [1, 5, 10, 20, 50, 100, 500, 1000]
                                 }
                             }
-                        },
-                        "latency_ms_bucketed": {
-                            "type": "integer",
-                            "description": "How long the credential import took in milliseconds, bucketed to preserve privacy",
-                            "enum": [1, 5, 10, 20, 50, 100, 500, 1000, 5000, 10000]
                         },
                         "failure_detail": {
                             "type": "string",

--- a/tests/test_data/invalid/wide_events/generated_schemas/w_wide_import_summary-1.0.0.json
+++ b/tests/test_data/invalid/wide_events/generated_schemas/w_wide_import_summary-1.0.0.json
@@ -42,6 +42,11 @@
                     "required": ["ext"],
                     "additionalProperties": false,
                     "properties": {
+                        "latency_ms_bucketed": {
+                            "type": "integer",
+                            "description": "How long the import operation took in milliseconds, bucketed to preserve privacy",
+                            "enum": [1, 5, 10, 20, 50, 100, 500, 1000, 5000, 10000]
+                        },
                         "ext": {
                             "type": "object",
                             "additionalProperties": false,
@@ -90,11 +95,6 @@
                                     "enum": [1, 5, 10, 20, 50, 100, 500, 1000]
                                 }
                             }
-                        },
-                        "latency_ms_bucketed": {
-                            "type": "integer",
-                            "description": "How long the import operation took in milliseconds, bucketed to preserve privacy",
-                            "enum": [1, 5, 10, 20, 50, 100, 500, 1000, 5000, 10000]
                         },
                         "failure_detail": {
                             "type": "string",

--- a/tests/test_data/invalid/wide_events/generated_schemas/w_wide_import_timeout-1.0.0.json
+++ b/tests/test_data/invalid/wide_events/generated_schemas/w_wide_import_timeout-1.0.0.json
@@ -42,6 +42,7 @@
                     "required": ["ext"],
                     "additionalProperties": false,
                     "properties": {
+                        "failure_detail": { "type": "string", "description": "Failure detail for timeout", "enum": ["TimeoutFailure"] },
                         "ext": {
                             "type": "object",
                             "additionalProperties": false,
@@ -70,8 +71,7 @@
                                     "enum": [1, 5, 10, 20, 50, 100, 500, 1000]
                                 }
                             }
-                        },
-                        "failure_detail": { "type": "string", "description": "Failure detail for timeout", "enum": ["TimeoutFailure"] }
+                        }
                     }
                 }
             }

--- a/tests/test_data/valid/wide_events/definitions/wide_events.json
+++ b/tests/test_data/valid/wide_events/definitions/wide_events.json
@@ -6,7 +6,7 @@
             "type": "w_wide_import_summary",
             "version": "0.0"
         },
-        "context": ["onboarding", "settings"],
+        "context": { "name": ["onboarding", "settings"] },
         "feature": {
             "name": "browser-import",
             "status": ["SUCCESS", "FAILURE", "CANCELLED"],
@@ -66,7 +66,7 @@
             "type": "w_wide_import_bookmarks",
             "version": "0.1"
         },
-        "context": ["onboarding.import", "settings.import"],
+        "context": { "name": ["onboarding.import", "settings.import"] },
         "feature": {
             "name": "browser-import-bookmarks",
             "status": ["SUCCESS", "FAILURE"],
@@ -102,7 +102,7 @@
             "type": "w_wide_import_credentials",
             "version": "0.1"
         },
-        "context": ["onboarding.import", "settings.import"],
+        "context": { "name": ["onboarding.import", "settings.import"] },
         "feature": {
             "name": "browser-import-credentials",
             "status": ["SUCCESS", "FAILURE"],
@@ -147,7 +147,7 @@
             "type": "w_wide_import_timeout",
             "version": "1.0"
         },
-        "context": ["onboarding", "settings"],
+        "context": { "name": ["onboarding", "settings"] },
         "feature": {
             "name": "browser-import",
             "status": ["FAILURE"],
@@ -187,7 +187,7 @@
             "type": "w_wide_import_cancelled",
             "version": "1.0"
         },
-        "context": ["onboarding", "settings"],
+        "context": { "name": ["onboarding", "settings"] },
         "feature": {
             "name": "browser-import",
             "status": ["CANCELLED"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
         "strictNullChecks": true,
         "maxNodeModuleJsDepth": 0,
         "useUnknownInCatchVariables": false,
-        "typeRoots": ["./node_modules/@types", "./types"]
+        "typeRoots": ["./node_modules/@types", "./types"],
+        "types": ["node"]
     },
     "include": ["main.mjs", "bin/**/*.mjs", "src/**/*.mjs"],
     "exclude": []


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/59792373528535/task/1213918713228104?focus=true


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes wide event metaschema/validation and the generated JSON Schemas (including required section shape and `app` vs `service` exclusivity), which can break downstream producers/validators. Dependency upgrades (notably `typescript`, `yargs`, `chai`) and Jenkins checkout behavior may also affect CI behavior.
> 
> **Overview**
> Updates wide event metaschema and schema generation to support new sections and stricter structure. Wide events now support *either* `app` *or* `service` (mutually exclusive), add optional `journey`, and extend `app` with `dev_mode`; `feature` gains `status_reason`, and `context` definitions are updated to the object form (`{ name: [...] }`) used for enum generation.
> 
> Refactors `WideEventDefinitionsValidator` to generate schemas generically from section names (base sections from `base_event`, event sections from the event definition), disallowing `app`/`service`/`global` inside per-event definitions, and updates tests + fixture definitions/generated schemas accordingly.
> 
> Bumps package version to `2.1.2`, upgrades multiple runtime/dev dependencies (e.g. `typescript@6`, `yargs@18`, `chai@6`), adds `types: ["node"]` to `tsconfig.json`, and adjusts Jenkins checkouts to clean/prune workspaces before fetching repos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e963991299fae88261c631803116079f363941cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->