### PR TITLE
Fix array support

### DIFF
--- a/src/live_pixel_validator.mjs
+++ b/src/live_pixel_validator.mjs
@@ -71,7 +71,7 @@ export class LivePixelsValidator {
     /**
      * @param {String} paramValue
      * @param {import('ajv').SchemaObject | undefined} paramSchema - AJV schema fragment
-     * @returns {string|object|array|null} decoded and normalized param value
+     * @returns {string|object|Array<string>|null} decoded and normalized param value
      */
     #getDecodedAndNormalizedVal(paramValue, paramSchema) {
         if (!paramSchema) return null; // will fail validation later

--- a/src/live_pixel_validator.mjs
+++ b/src/live_pixel_validator.mjs
@@ -71,7 +71,7 @@ export class LivePixelsValidator {
     /**
      * @param {String} paramValue
      * @param {import('ajv').SchemaObject | undefined} paramSchema - AJV schema fragment
-     * @returns {String|null} decoded and normalized param value
+     * @returns {string|object|array|null} decoded and normalized param value
      */
     #getDecodedAndNormalizedVal(paramValue, paramSchema) {
         if (!paramSchema) return null; // will fail validation later
@@ -103,8 +103,12 @@ export class LivePixelsValidator {
             updatedVal = updatedVal.toLowerCase();
         }
 
-        if (paramSchema.type === 'object') {
-            updatedVal = JSON.parse(updatedVal);
+        if (paramSchema.type === 'object' || paramSchema.type === 'array') {
+            try {
+                updatedVal = JSON.parse(updatedVal);
+            } catch (parseErr) {
+                // Keep the raw value so AJV can report a schema mismatch downstream
+            }
         }
 
         return updatedVal;

--- a/tests/live_pixel_validation_test.mjs
+++ b/tests/live_pixel_validation_test.mjs
@@ -307,6 +307,53 @@ describe('Base64 simple param', () => {
     });
 });
 
+describe('Array params', () => {
+    const paramsValidator = new ParamsValidator({}, {}, {});
+    const prefix = 'arrayPixel';
+    const pixelDefs = {
+        arrayPixel: {
+            parameters: [
+                {
+                    key: 'trackers_blocked',
+                    type: 'array',
+                    items: {
+                        type: 'string',
+                        enum: ['tracker1', 'tracker2', 'tracker3'],
+                    },
+                },
+            ],
+        },
+    };
+
+    const tokenizedDefs = {};
+    tokenizePixelDefs(pixelDefs, tokenizedDefs);
+    const liveValidator = new LivePixelsValidator(tokenizedDefs, productDef, {}, paramsValidator);
+
+    it('accepts JSON-encoded array params', () => {
+        const params = `trackers_blocked=${encodeURIComponent(JSON.stringify(['tracker1', 'tracker2']))}`;
+        const pixelStatus = liveValidator.validatePixel(prefix, params);
+        expect(pixelStatus.errors).to.be.empty;
+    });
+
+    it('rejects invalid array items', () => {
+        const params = `trackers_blocked=${encodeURIComponent(JSON.stringify(['tracker1', 'invalidTracker']))}`;
+        const pixelStatus = liveValidator.validatePixel(prefix, params);
+        const expectedErrors = ['/trackers_blocked/1 must be equal to one of the allowed values'];
+        expect(pixelStatus.status).to.equal(PIXEL_VALIDATION_RESULT.VALIDATION_FAILED);
+        expect(pixelStatus.errors.map((e) => e.error)).to.have.members(expectedErrors);
+        expect(pixelStatus.errors.map((e) => e.example)).to.have.members([params]);
+    });
+
+    it('rejects non-array values for array params', () => {
+        const params = 'trackers_blocked=tracker1';
+        const pixelStatus = liveValidator.validatePixel(prefix, params);
+        const expectedErrors = ['/trackers_blocked must be array'];
+        expect(pixelStatus.status).to.equal(PIXEL_VALIDATION_RESULT.VALIDATION_FAILED);
+        expect(pixelStatus.errors.map((e) => e.error)).to.have.members(expectedErrors);
+        expect(pixelStatus.errors.map((e) => e.example)).to.have.members([params]);
+    });
+});
+
 describe('App version outdated', () => {
     const productDefWithVersion = {
         target: {

--- a/tests/test_data/valid/pixels/definitions/pixel_guide.json5
+++ b/tests/test_data/valid/pixels/definitions/pixel_guide.json5
@@ -63,6 +63,18 @@
                 "examples": [["tracker1", "tracker2"], ["tracker3"]]
             },
             {
+                "key": "colors",
+                "description": "UI colors",
+                // Array with bounded values
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["red", "green", "blue"]
+                },
+                // Examples
+                "examples": [["red", "green"], ["blue"]]
+            },
+            {
                 "key": "customMetadata",
                 "description": "Complex object type",
                 // See https://json-schema.org/understanding-json-schema/reference/object

--- a/tests/test_data/valid/pixels/expected_processing_results/pixel_errors.json
+++ b/tests/test_data/valid/pixels/expected_processing_results/pixel_errors.json
@@ -31,6 +31,9 @@
         ],
         "/count must be integer": [
             "count=wrongFormat&appVersion=2.0.0"
+        ],
+        "/colors/1 must be equal to one of the allowed values": [
+            "colors=%5B%22red%22,%22unexpected_array_value%22%5D&appVersion=2.0.3"
         ]
     },
     "experiment_enroll_defaultBrowser_control": {

--- a/tests/test_data/valid/pixels/expected_processing_results/tokenized_pixels.json
+++ b/tests/test_data/valid/pixels/expected_processing_results/tokenized_pixels.json
@@ -44,6 +44,28 @@
                                 ]
                             },
                             {
+                                "key": "colors",
+                                "description": "UI colors",
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "red",
+                                        "green",
+                                        "blue"
+                                    ]
+                                },
+                                "examples": [
+                                    [
+                                        "red",
+                                        "green"
+                                    ],
+                                    [
+                                        "blue"
+                                    ]
+                                ]
+                            },
+                            {
                                 "key": "customMetadata",
                                 "description": "Complex object type",
                                 "type": "object",

--- a/tests/test_data/valid/pixels/test_live_pixels.csv
+++ b/tests/test_data/valid/pixels/test_live_pixels.csv
@@ -14,6 +14,8 @@ m.my.first.pixel.skip-due-to-version,"['count=unexpectedButSkip']",appVersion=0.
 m.my.first.pixel,"['count=wrongFormat']",appVersion=2.0.0
 m.my.first.pixel,"['count=42', 'date=2025-03-12']",appVersion=2.0.3
 m.my.first.pixel,['count=42'],
+m.my.first.pixel,"['colors=%5B%22red%22,%22unexpected_array_value%22%5D']",appVersion=2.0.3
+m.my.first.pixel,"['colors=%5B%22red%22,%22blue%22%5D']",appVersion=2.0.3
 experiment.enroll.defaultBrowser.control,"['enrollmentDate=2025-04-22', 'conversionWindowDays=8-15']",
 experiment.enroll.defaultBrowser.control,"['enrollmentDate=not_a_date', 'conversionWindowDays=x-x-x']",
 experiment.enroll.x,[],


### PR DESCRIPTION
**Asana task**: https://app.asana.com/1/137249556945/project/1209805270658160/task/1211832455007427?focus=true
* See also https://app.asana.com/1/137249556945/task/1214280563850698?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how querystring param values are decoded and JSON-parsed for `object`/`array` schemas, which can affect validation outcomes for existing pixels and error reporting.
> 
> **Overview**
> Improves live pixel parameter decoding to properly support JSON-encoded `array` parameters: `#getDecodedAndNormalizedVal` now attempts `JSON.parse` for both `object` and `array` param schemas.
> 
> Makes JSON parsing *non-fatal* by swallowing parse errors and leaving the raw string value so AJV can surface type/schema mismatches, and extends test coverage plus fixture data to validate valid/invalid array item handling (including bounded enum arrays like `colors`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1609e189f64938aff91591cde61a513796f1cde7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->