### PR TITLE
Add support for Android version files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "js-yaml": "^4.1.1",
                 "json-schema-traverse": "^1.0.0",
                 "json5": "^2.2.3",
+                "properties": "^1.2.1",
                 "typescript": "^6.0.3",
                 "yargs": "^18.0.0"
             },
@@ -4346,6 +4347,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/properties": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/properties/-/properties-1.2.1.tgz",
+            "integrity": "sha512-qYNxyMj1JeW54i/EWEFsM1cVwxJbtgPp8+0Wg9XjNaK6VE/c4oRi6PNu5p7w1mNXEIQIjV5Wwn8v8Gz82/QzdQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10"
             }
         },
         "node_modules/punycode": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "js-yaml": "^4.1.1",
                 "json-schema-traverse": "^1.0.0",
                 "json5": "^2.2.3",
-                "properties": "^1.2.1",
+                "properties-file": "^5.0.4",
                 "typescript": "^6.0.3",
                 "yargs": "^18.0.0"
             },
@@ -4349,13 +4349,13 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/properties": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/properties/-/properties-1.2.1.tgz",
-            "integrity": "sha512-qYNxyMj1JeW54i/EWEFsM1cVwxJbtgPp8+0Wg9XjNaK6VE/c4oRi6PNu5p7w1mNXEIQIjV5Wwn8v8Gz82/QzdQ==",
+        "node_modules/properties-file": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/properties-file/-/properties-file-5.0.4.tgz",
+            "integrity": "sha512-c3CqZLWoNN+zQvpn4z8GgVdBGWlSzbjPumDk1Yri2bdbw7CMzaOgoPsj271kJzNwznEtt4tIDByhZjrw1LzKBw==",
             "license": "MIT",
             "engines": {
-                "node": ">=0.10"
+                "node": ">=0.4.0"
             }
         },
         "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "js-yaml": "^4.1.1",
         "json-schema-traverse": "^1.0.0",
         "json5": "^2.2.3",
-        "properties": "^1.2.1",
+        "properties-file": "^5.0.4",
         "typescript": "^6.0.3",
         "yargs": "^18.0.0"
     },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "js-yaml": "^4.1.1",
         "json-schema-traverse": "^1.0.0",
         "json5": "^2.2.3",
+        "properties": "^1.2.1",
         "typescript": "^6.0.3",
         "yargs": "^18.0.0"
     },

--- a/src/pixel_utils.mjs
+++ b/src/pixel_utils.mjs
@@ -1,4 +1,5 @@
 import { PIXEL_DELIMITER, ROOT_PREFIX } from './constants.mjs';
+import properties from 'properties';
 
 /**
  * @typedef {Object} SearchExperimentDefinition
@@ -177,7 +178,14 @@ export async function resolveTargetVersion(target) {
         if (!response.ok) {
             throw new Error(`Failed to fetch version from ${target.versionUrl}: ${response.status} ${response.statusText}`);
         }
-        const data = await response.json();
+        const responseText = await response.text();
+        let data;
+        try {
+            data = JSON.parse(responseText);
+        } catch {
+            // namespace is used to support nested key paths
+            data = properties.parse(responseText, { namespaces: true });
+        }
         const version = getValueByKeyPath(data, target.versionRef);
         if (version === undefined) {
             throw new Error(`Version key "${target.versionRef}" not found in response from ${target.versionUrl}`);

--- a/src/pixel_utils.mjs
+++ b/src/pixel_utils.mjs
@@ -1,5 +1,5 @@
 import { PIXEL_DELIMITER, ROOT_PREFIX } from './constants.mjs';
-import properties from 'properties';
+import { getProperties } from 'properties-file';
 
 /**
  * @typedef {Object} SearchExperimentDefinition
@@ -179,14 +179,14 @@ export async function resolveTargetVersion(target) {
             throw new Error(`Failed to fetch version from ${target.versionUrl}: ${response.status} ${response.statusText}`);
         }
         const responseText = await response.text();
-        let data;
+        let version;
         try {
-            data = JSON.parse(responseText);
+            const data = JSON.parse(responseText);
+            version = getValueByKeyPath(data, target.versionRef);
         } catch {
-            // namespace is used to support nested key paths
-            data = properties.parse(responseText, { namespaces: true });
+            const data = getProperties(responseText);
+            version = data ? data[target.versionRef] : undefined;
         }
-        const version = getValueByKeyPath(data, target.versionRef);
         if (version === undefined) {
             throw new Error(`Version key "${target.versionRef}" not found in response from ${target.versionUrl}`);
         }

--- a/tests/version_resolution_test.mjs
+++ b/tests/version_resolution_test.mjs
@@ -107,6 +107,32 @@ describe('resolveTargetVersion', () => {
             expect(version).to.equal('1.104.0');
         });
 
+        it('should fetch version from .properties response with simple key path', async () => {
+            nock('https://example.com').get('/version.properties').reply(200, 'version=3.2.1');
+
+            const target = {
+                key: 'appVersion',
+                versionUrl: 'https://example.com/version.properties',
+                versionRef: 'version',
+            };
+
+            const version = await resolveTargetVersion(target);
+            expect(version).to.equal('3.2.1');
+        });
+
+        it('should fetch version from .properties response with nested key path', async () => {
+            nock('https://example.com').get('/metadata.properties').reply(200, 'latest_appstore_version.latest_version=1.205.0');
+
+            const target = {
+                key: 'appVersion',
+                versionUrl: 'https://example.com/metadata.properties',
+                versionRef: 'latest_appstore_version.latest_version',
+            };
+
+            const version = await resolveTargetVersion(target);
+            expect(version).to.equal('1.205.0');
+        });
+
         it('should throw when URL returns 404', async () => {
             nock('https://example.com').get('/notfound.json').reply(404, 'Not Found');
 

--- a/tests/version_resolution_test.mjs
+++ b/tests/version_resolution_test.mjs
@@ -120,8 +120,8 @@ describe('resolveTargetVersion', () => {
             expect(version).to.equal('3.2.1');
         });
 
-        it('should fetch version from .properties response with nested key path', async () => {
-            nock('https://example.com').get('/metadata.properties').reply(200, 'latest_appstore_version.latest_version=1.205.0');
+        it('should fetch version from .properties response with nested key path and converts to string', async () => {
+            nock('https://example.com').get('/metadata.properties').reply(200, 'latest_appstore_version.latest_version=205.0');
 
             const target = {
                 key: 'appVersion',
@@ -130,7 +130,7 @@ describe('resolveTargetVersion', () => {
             };
 
             const version = await resolveTargetVersion(target);
-            expect(version).to.equal('1.205.0');
+            expect(version).to.equal('205.0');
         });
 
         it('should throw when URL returns 404', async () => {


### PR DESCRIPTION
**Asana task**: https://app.asana.com/1/137249556945/project/1209805270658160/task/1213209969016052?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches remote version-resolution logic by changing response parsing to handle non-JSON payloads, which could affect existing JSON-based version URLs if parsing behavior differs. Coverage is improved via new tests for `.properties` parsing, reducing but not eliminating integration risk with real endpoints.
> 
> **Overview**
> Adds support for resolving `target.versionUrl` values from Android-style `.properties` files in `resolveTargetVersion`.
> 
> Instead of assuming JSON, the resolver now reads the response as text, attempts `JSON.parse`, and falls back to parsing `.properties` (with namespaces) so dot-path `versionRef` lookups work for both formats. Dependencies are updated to include `properties`, and tests add cases for simple and nested `.properties` key paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ab8cd4e9d2ff53c4fd14006b804efd2d7d2ced. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->