### PR TITLE
Add journey id to the wide event schema and update app.form_factor

### DIFF
--- a/schemas/wide_event_schema.json5
+++ b/schemas/wide_event_schema.json5
@@ -336,9 +336,10 @@
                 "additionalProperties": { "const": false },
                 "properties": {
                     "type": "object",
-                    "required": ["name"],
+                    "required": ["name", "id"],
                     "properties": {
-                        "name": { "$ref": "#/$defs/stringEnumProperty" }
+                        "name": { "$ref": "#/$defs/stringEnumProperty" },
+                        "id": { "$ref": "#/$defs/stringValueWithPatternProperty" }
                     },
                     "additionalProperties": false
                 }

--- a/schemas/wide_event_schema.json5
+++ b/schemas/wide_event_schema.json5
@@ -66,7 +66,7 @@
                 "description": { "type": "string" },
                 "enum": {
                     "type": "array",
-                    "items": { "enum": ["phone", "tablet"] }
+                    "items": { "enum": ["phone", "tablet", "desktop", "mobile"] }
                 }
             },
             "additionalProperties": false

--- a/schemas/wide_event_schema.json5
+++ b/schemas/wide_event_schema.json5
@@ -336,7 +336,7 @@
                 "additionalProperties": { "const": false },
                 "properties": {
                     "type": "object",
-                    "required": ["name", "id"],
+                    "required": ["name"],
                     "properties": {
                         "name": { "$ref": "#/$defs/stringEnumProperty" },
                         "id": { "$ref": "#/$defs/stringValueWithPatternProperty" }

--- a/tests/pixel_definition_validation_test.mjs
+++ b/tests/pixel_definition_validation_test.mjs
@@ -1466,7 +1466,7 @@ describe('Wide Event journey section handling', () => {
         const generated = generatedSchemas.w_with_journey;
         expect(generated.properties).to.have.property('journey');
         expect(generated.required).to.include('journey');
-        expect(generated.properties.journey.required).to.deep.equal(['name', 'id']);
+        expect(generated.properties.journey.required).to.deep.equal(['name']);
         expect(generated.properties.journey.properties.name.enum).to.deep.equal(['first_run', 'returning_user']);
     });
 

--- a/tests/pixel_definition_validation_test.mjs
+++ b/tests/pixel_definition_validation_test.mjs
@@ -1265,7 +1265,7 @@ describe('Wide Event required fields follow metaschema', () => {
         app: {
             name: { type: 'string', description: 'App name', enum: ['Windows'] },
             version: { type: 'string', description: 'App version', pattern: '^[0-9]+\\.[0-9]+\\.[0-9]+$' },
-            form_factor: { type: 'string', description: 'Form factor', enum: ['phone', 'tablet'] },
+            form_factor: { type: 'string', description: 'Form factor', enum: ['phone', 'tablet', 'desktop', 'mobile'] },
         },
         global: {
             platform: { type: 'string', description: 'Platform', enum: ['Windows'] },

--- a/tests/pixel_definition_validation_test.mjs
+++ b/tests/pixel_definition_validation_test.mjs
@@ -1443,6 +1443,7 @@ describe('Wide Event journey section handling', () => {
         },
         journey: {
             name: { type: 'string', description: 'Journey name' },
+            id: { type: 'string', description: 'Journey id', pattern: '^[0-9a-f]{32}$' },
         },
     };
 
@@ -1465,7 +1466,7 @@ describe('Wide Event journey section handling', () => {
         const generated = generatedSchemas.w_with_journey;
         expect(generated.properties).to.have.property('journey');
         expect(generated.required).to.include('journey');
-        expect(generated.properties.journey.required).to.deep.equal(['name']);
+        expect(generated.properties.journey.required).to.deep.equal(['name', 'id']);
         expect(generated.properties.journey.properties.name.enum).to.deep.equal(['first_run', 'returning_user']);
     });
 

--- a/tests/pixel_definition_validation_test.mjs
+++ b/tests/pixel_definition_validation_test.mjs
@@ -1470,6 +1470,29 @@ describe('Wide Event journey section handling', () => {
         expect(generated.properties.journey.properties.name.enum).to.deep.equal(['first_run', 'returning_user']);
     });
 
+    it('carries the optional journey id from base_event without requiring it', () => {
+        const event = {
+            w_journey_with_id: {
+                description: 'Event whose journey carries the base id',
+                owners: ['tester'],
+                meta: { type: 'w_journey_with_id', version: '0.0' },
+                journey: { name: ['first_run'] },
+                feature: {
+                    name: 'journey-with-id',
+                    status: ['SUCCESS'],
+                    data: { ext: {} },
+                },
+            },
+        };
+        const { errors, generatedSchemas } = makeValidator().validateWideEventDefinition(event, baseEvent);
+        expect(errors).to.be.empty;
+        const generated = generatedSchemas.w_journey_with_id;
+        expect(generated.properties.journey.properties).to.have.property('id');
+        expect(generated.properties.journey.properties.id.pattern).to.equal('^[0-9a-f]{32}$');
+        expect(generated.properties.journey.required).to.deep.equal(['name']);
+        expect(generated.properties.journey.required).to.not.include('id');
+    });
+
     it('omits journey section when event definition does not provide it', () => {
         const event = {
             w_without_journey: {
@@ -1518,5 +1541,60 @@ describe('Wide Event journey section handling', () => {
         expect(generated.properties).to.have.property('journey');
         expect(generated.properties.journey.properties.name.enum).to.deep.equal(['onboarding']);
         expect(generated.properties.context.properties.name.enum).to.deep.equal(['settings']);
+    });
+});
+
+describe('Wide Event form_factor enum handling', () => {
+    const makeValidator = () => new WideEventDefinitionsValidator({});
+
+    const makeBaseEvent = (formFactorEnum) => ({
+        meta: {
+            version: {
+                description: 'Base event version',
+                value: 1,
+            },
+        },
+        app: {
+            name: { type: 'string', description: 'App name', enum: ['Windows'] },
+            version: { type: 'string', description: 'App version', pattern: '^[0-9]+\\.[0-9]+\\.[0-9]+$' },
+            form_factor: { type: 'string', description: 'Form factor', enum: formFactorEnum },
+        },
+        global: {
+            platform: { type: 'string', description: 'Platform', enum: ['Windows'] },
+            type: { type: 'string', description: 'Type', enum: ['app'] },
+            sample_rate: { type: 'number', description: 'Sample rate', minimum: 0, maximum: 1 },
+        },
+        feature: {
+            name: { type: 'string', description: 'Feature name' },
+            status: { type: 'string', description: 'Status' },
+            data: { ext: {} },
+        },
+    });
+
+    const event = {
+        w_form_factor: {
+            description: 'Event exercising form_factor values',
+            owners: ['tester'],
+            meta: { type: 'w_form_factor', version: '0.0' },
+            feature: {
+                name: 'form-factor-feature',
+                status: ['SUCCESS'],
+                data: { ext: {} },
+            },
+        },
+    };
+
+    it('accepts the desktop and mobile form_factor values', () => {
+        const baseEvent = makeBaseEvent(['phone', 'tablet', 'desktop', 'mobile']);
+        const { errors, generatedSchemas } = makeValidator().validateWideEventDefinition(event, baseEvent);
+        expect(errors).to.be.empty;
+        const generated = generatedSchemas.w_form_factor;
+        expect(generated.properties.app.properties.form_factor.enum).to.deep.equal(['phone', 'tablet', 'desktop', 'mobile']);
+    });
+
+    it('rejects form_factor values outside the metaschema enum', () => {
+        const baseEvent = makeBaseEvent(['laptop']);
+        const { errors } = makeValidator().validateWideEventDefinition(event, baseEvent);
+        expect(errors.some((error) => error.includes('Generated schema does not match metaschema'))).to.be.true;
     });
 });


### PR DESCRIPTION
Add journey id to the wide event metaschema so validation is successful.

Also add "desktop" and "mobile" to the form_factor enum


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and validation-test changes only; no runtime logic or data pipelines touched.
> 
> **Overview**
> Updates the wide event **metaschema** so far enough for real base events and generated schemas to validate.
> 
> **`app.form_factor`** now allows **`desktop`** and **`mobile`** in addition to **`phone`** and **`tablet`**, so base events can describe those device classes without failing metaschema checks.
> 
> The **journey** section gains an optional **`id`** field (32-char hex via `stringValueWithPatternProperty`), merged from `base_event` like other base-only properties. **`name`** stays the only required journey field when an event includes journey.
> 
> Tests cover optional journey **`id`** propagation, **`form_factor`** acceptance/rejection against the metaschema enum, and align fixtures with the new enum values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2e2bb5abc9b0b9824ecd76107614bd804007ee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->