### PR TITLE
add "kc" and "kac" to ignore params

### DIFF
--- a/global_pixel_definitions/ignore_params.json
+++ b/global_pixel_definitions/ignore_params.json
@@ -9,6 +9,16 @@
         "description": "added by 3rd party proxies for SERP",
         "enum": [1]
     },
+    "kc": {
+        "key": "kc",
+        "description": "added by 3rd party proxies for SERP",
+        "enum": [-1]
+    },
+    "kac": {
+        "key": "kac",
+        "description": "added by 3rd party proxies for SERP",
+        "enum": [-1]
+    },
     "test": {
         "key": "test",
         "description": "",


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1209805270658160/task/1214934152266987?focus=true

Looks like it can occasionally occur for non-Windows pixels (which makes sense if via proxy injection)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only additions to `ignore_params.json` with no runtime logic changes; only affects which URL params pass pixel definition validation.
> 
> **Overview**
> Extends the global pixel **ignore params** list so validation no longer treats **`kc`** and **`kac`** as unknown query parameters when third-party SERP proxies inject them (same treatment as existing **`kp`** / **`p`** entries, with allowed value **`-1`**).
> 
> This should reduce false validation noise on non-Windows pixels when those params appear in URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 526aee6746dfc2ab1d6be52830a31311378b8d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->