### PR TITLE
include app ver in reports

### DIFF
--- a/live_validation_scripts/asana_reports.mjs
+++ b/live_validation_scripts/asana_reports.mjs
@@ -243,6 +243,7 @@ async function main() {
     readAsanaNotifyFile(dirPath);
 
     // Resolve the app version used as the live validation target.
+    // An app release between validation CH fetch and report generation could make this differ from the version validation used, but this window is very small.
     const productDef = fileUtils.readProductDef(dirPath);
     targetVersion = await resolveTargetVersion(productDef.target);
     if (targetVersion) {
@@ -355,9 +356,9 @@ async function main() {
     // Add attachment after task creation if there are pixels with errors
     if (numPixelsWithErrors > 0) {
         try {
-            /*  
+            /*
                 To avoid deleting attachments used for other purposes
-                delete_attachments.mjs looks for attachments that start with ASANA_and end with .json 
+                delete_attachments.mjs looks for attachments that start with ASANA_and end with .json
                 if we change that modify delete_attachments
             */
             const attachmentResult = await superagent.default

--- a/live_validation_scripts/asana_reports.mjs
+++ b/live_validation_scripts/asana_reports.mjs
@@ -7,7 +7,9 @@ import yaml from 'js-yaml';
 
 import * as fileUtils from '../src/file_utils.mjs';
 import { getArgParserAsanaReports } from '../src/args_utils.mjs';
+import { getPixelFailureMessage } from '../src/asana_report_copy.mjs';
 import { DDG_ASANA_WORKSPACEID, DAYS_TO_DELETE_ATTACHMENTS, ASANA_TASK_PREFIX, ASANA_ATTACHMENT_PREFIX } from '../src/constants.mjs';
+import { resolveTargetVersion } from '../src/pixel_utils.mjs';
 
 const MAKE_PER_OWNER_SUBTASKS = true;
 
@@ -27,34 +29,7 @@ let ownerToPixelsMap = {};
 let userMap = null;
 
 const toNotify = {};
-
-// URL to the instructions task in Asanathat explains the report and its contents
-const INSTRUCTIONS_TASK_URL = 'https://app.asana.com/1/137249556945/project/1210856607616307/task/1210948723611775?focus=true';
-function getPixelFailureMessage(numFailures, isPerOwnerTask) {
-    if (numFailures === 0) {
-        return `No errors found.`;
-    }
-
-    let pixelPhrase = `${numFailures} `;
-    pixelPhrase += numFailures === 1 ? ' pixel' : 'pixels';
-    if (isPerOwnerTask) {
-        pixelPhrase += ' that you own';
-    }
-    pixelPhrase += numFailures === 1 ? ' has' : ' have';
-    pixelPhrase += ' failed live validation.';
-
-    if (isPerOwnerTask) {
-        pixelPhrase += ' Table below lists the errors encountered - check the attachment for examples of pixels triggering each error.';
-    } else {
-        pixelPhrase += ' Check per-owner subtasks and/or the attachment for details.';
-    }
-
-    pixelPhrase += `
-
- New to these reports ? See <a href="${INSTRUCTIONS_TASK_URL}">View task</a>`;
-
-    return `${pixelPhrase}`;
-}
+let targetVersion = null;
 
 function readAsanaNotifyFile() {
     const notifyFile = path.join(dirPath, 'asana_notify.json');
@@ -129,7 +104,7 @@ async function createOwnerSubtask(owner, parentTaskGid, ownersPixelData) {
     fs.writeFileSync(tempFilePath, JSON.stringify(ownersPixelData, null, 4));
 
     const numPixels = Object.keys(ownersPixelData).length;
-    const pixelPhrase = getPixelFailureMessage(numPixels, true);
+    const pixelPhrase = getPixelFailureMessage(numPixels, true, targetVersion);
     const header = `${pixelPhrase}`;
 
     const pixelNameWidth = 200;
@@ -267,6 +242,15 @@ async function main() {
     // Load the asana notify file
     readAsanaNotifyFile(dirPath);
 
+    // Resolve the app version used as the live validation target.
+    const productDef = fileUtils.readProductDef(dirPath);
+    targetVersion = await resolveTargetVersion(productDef.target);
+    if (targetVersion) {
+        console.log(`Target app version: ${targetVersion}`);
+    } else {
+        console.log('No target app version configured');
+    }
+
     // Allow NOTIFY_PIXEL_OWNERS env var to override the tagPixelOwners setting from asana_notify.json
     if (process.env.NOTIFY_PIXEL_OWNERS !== undefined) {
         const envNotifyOwners = process.env.NOTIFY_PIXEL_OWNERS.toLowerCase() === 'true';
@@ -324,7 +308,7 @@ async function main() {
 
     console.log(taskName);
 
-    const pixelPhrase = getPixelFailureMessage(numPixelsWithErrors, false);
+    const pixelPhrase = getPixelFailureMessage(numPixelsWithErrors, false, targetVersion);
 
     // For valid formatting options: https://developers.asana.com/docs/rich-text#reading-rich-text
     const taskNotes = `<body> ${pixelPhrase} </body>`;

--- a/src/asana_report_copy.mjs
+++ b/src/asana_report_copy.mjs
@@ -1,0 +1,56 @@
+const INSTRUCTIONS_TASK_URL = 'https://app.asana.com/1/137249556945/project/1210856607616307/task/1210948723611775?focus=true';
+
+const VERSION_WARNING =
+    "If you've changed the pixel post this release, you may see a false positive alert for any parameters that were removed from the schema but are still present in the currently released version. This should be resolved by the next app release.";
+
+/**
+ * Escape text interpolated into Asana HTML notes.
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeHtml(value) {
+    return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+/**
+ * Build the introductory copy for a live validation report.
+ * @param {number} numFailures
+ * @param {boolean} isPerOwnerTask
+ * @param {string|null} targetVersion
+ * @returns {string}
+ */
+export function getPixelFailureMessage(numFailures, isPerOwnerTask, targetVersion) {
+    let message;
+
+    if (numFailures === 0) {
+        message = 'No errors found.';
+    } else {
+        let pixelPhrase = `${numFailures}`;
+        pixelPhrase += numFailures === 1 ? ' pixel' : 'pixels';
+        if (isPerOwnerTask) {
+            pixelPhrase += ' that you own';
+        }
+        pixelPhrase += numFailures === 1 ? ' has' : ' have';
+        pixelPhrase += ' failed live validation.';
+
+        if (isPerOwnerTask) {
+            pixelPhrase += ' Table below lists the errors encountered - check the attachment for examples of pixels triggering each error.';
+        } else {
+            pixelPhrase += ' Check per-owner subtasks and/or the attachment for details.';
+        }
+
+        message = `${pixelPhrase}
+
+New to these reports? See <a href="${INSTRUCTIONS_TASK_URL}">View task</a>`;
+    }
+
+    if (targetVersion) {
+        message += `
+
+<strong>Target app version:</strong> ${escapeHtml(targetVersion)}
+
+${VERSION_WARNING}`;
+    }
+
+    return message;
+}

--- a/src/asana_report_copy.mjs
+++ b/src/asana_report_copy.mjs
@@ -26,7 +26,7 @@ export function getPixelFailureMessage(numFailures, isPerOwnerTask, targetVersio
         message = 'No errors found.';
     } else {
         let pixelPhrase = `${numFailures}`;
-        pixelPhrase += numFailures === 1 ? ' pixel' : 'pixels';
+        pixelPhrase += numFailures === 1 ? ' pixel' : ' pixels';
         if (isPerOwnerTask) {
             pixelPhrase += ' that you own';
         }

--- a/tests/asana_report_copy_test.mjs
+++ b/tests/asana_report_copy_test.mjs
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+
+import { getPixelFailureMessage } from '../src/asana_report_copy.mjs';
+
+describe('Asana report copy', () => {
+    it('includes the target app version and release warning', () => {
+        const message = getPixelFailureMessage(2, false, '1.2.3');
+
+        expect(message).to.include('<strong>Target app version:</strong> 1.2.3');
+        expect(message).to.include(
+            "If you've changed the pixel post this release, you may see a false positive alert for any parameters that were removed from the schema but are still present in the currently released version. This should be resolved by the next app release.",
+        );
+    });
+
+    it('includes the target app version on per-owner subtasks', () => {
+        const message = getPixelFailureMessage(1, true, '1.2.3');
+
+        expect(message).to.include('1 pixel that you own has failed live validation.');
+        expect(message).to.include('<strong>Target app version:</strong> 1.2.3');
+    });
+
+    it('omits version copy for query-window products', () => {
+        const message = getPixelFailureMessage(2, false, null);
+
+        expect(message).not.to.include('Target app version');
+        expect(message).not.to.include("If you've changed the pixel post this release");
+    });
+
+    it('escapes the target version before adding it to HTML notes', () => {
+        const message = getPixelFailureMessage(0, false, '1.2.3<script>');
+
+        expect(message).to.include('<strong>Target app version:</strong> 1.2.3&lt;script&gt;');
+        expect(message).not.to.include('1.2.3<script>');
+    });
+});

--- a/tests/asana_report_copy_test.mjs
+++ b/tests/asana_report_copy_test.mjs
@@ -6,6 +6,7 @@ describe('Asana report copy', () => {
     it('includes the target app version and release warning', () => {
         const message = getPixelFailureMessage(2, false, '1.2.3');
 
+        expect(message).to.include('2 pixels have failed live validation.');
         expect(message).to.include('<strong>Target app version:</strong> 1.2.3');
         expect(message).to.include(
             "If you've changed the pixel post this release, you may see a false positive alert for any parameters that were removed from the schema but are still present in the currently released version. This should be resolved by the next app release.",


### PR DESCRIPTION
Task: https://app.asana.com/1/137249556945/project/1209805270658160/task/1216337048997836?focus=true

Minimal changes here, so worth noting a small race condition present for querying the app version when:
a) fetching from CH
b) generating the report

The window is pretty tiny, but if we want to bullet proof we could also cache the ver from step a) in a file.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk reporting and copy changes; version is fetched at report time (small mismatch vs validation fetch is documented) and untrusted version strings are escaped for Asana HTML.
> 
> **Overview**
> Live validation **Asana report** copy now surfaces the **target app version** (when the product defines one) on the parent task and per-owner subtasks, plus a short note about possible **false positives** after pixel schema changes post-release.
> 
> Report generation **resolves the version at run time** via `resolveTargetVersion` from `product.json`’s target; products without a version (e.g. query-window) omit that block. Message building moved to **`asana_report_copy.mjs`**, with **HTML escaping** for the version string in rich-text notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3e572db3c8f8bc7fb153b54b5a9dcd09a55feae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->